### PR TITLE
✨ Inspect package for SDK info and prompt to confirm or choose

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "@oclif/plugin-help": "^3.2.0",
     "@percy/cli-config": "^1.0.0-beta.35",
     "@percy/logger": "^1.0.0-beta.35",
-    "cross-spawn": "^7.0.3"
+    "cross-spawn": "^7.0.3",
+    "inquirer": "^7.3.3",
+    "semver": "^7.3.4"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.17",
@@ -59,6 +61,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "expect": "^26.4.2",
     "mocha": "^8.3.0",
+    "mock-require": "^3.0.3",
     "nyc": "^15.1.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,8 @@
 import Command, { flags } from '@oclif/command';
 import logger from '@percy/logger';
+import inquirer from 'inquirer';
+import inspectDeps from './inspect';
+import migrations from './migrations';
 
 class Migrate extends Command {
   static description = 'Upgrade and migrate your Percy SDK to the latest version';
@@ -56,8 +59,79 @@ class Migrate extends Command {
   }
 
   // Run migration steps
-  run() {
-    this.log.info('Coming soon');
+  async run() {
+    // inspect dependencies
+    let info = inspectDeps();
+
+    // get the desired sdk migration
+    let sdk = await this.confirmSDK(this.args.sdk_name, info.installed);
+
+    // install @percy/cli and migrate config
+    // if (!this.flags['skip-cli']) {
+    //   await this.confirmCLI(!!info.agent);
+    //   await this.confirmConfig();
+    // }
+
+    // perform sdk migration
+    if (sdk) {
+      // await this.confirmUpgrade(sdk);
+      // await this.confirmTransforms(sdk);
+      this.log.info('Migration complete!');
+    } else {
+      this.log.info('See further migration instructions here: ' + (
+        'https://docs.percy.io/docs/migrating-to-percy-cli'));
+    }
+  }
+
+  // Confirms if the first SDK in the list is the current SDK, otherwise will present a list of
+  // supported SDKs to choose from, erroring when the chosen SDK is not in the list
+  async confirmSDK(name, installed) {
+    let fromInstalled = SDK => {
+      let sdk = installed.find(sdk => sdk instanceof SDK) || new SDK();
+      if (!sdk.installed) this.log.warn('The specified SDK was not found in your dependencies');
+      return sdk;
+    };
+
+    // don't guess or prompt when a name is provided
+    if (name) {
+      let SDK = migrations.find(SDK => SDK.matches(name));
+      if (SDK) return fromInstalled(SDK);
+      this.log.warn('The specified SDK is not supported');
+      return;
+    }
+
+    // ask to confirm first guess
+    let [guess] = installed;
+
+    if (guess) {
+      let { isGuess } = await inquirer.prompt([{
+        type: 'confirm',
+        name: 'isGuess',
+        message: `Are you currently using ${guess.aliased}?`,
+        default: true
+      }]);
+
+      if (isGuess) {
+        return guess;
+      }
+    }
+
+    // ask to choose from list of supported sdks
+    let { fromChoice } = await inquirer.prompt([{
+      type: 'list',
+      name: 'fromChoice',
+      message: 'Which SDK are you using?',
+      default: guess ? migrations.indexOf(guess.constructor) : 0,
+      choices: migrations.map(SDK => ({
+        name: SDK.aliased,
+        value: () => fromInstalled(SDK)
+      })).concat({
+        name: '...not listed?',
+        value: null
+      })
+    }]);
+
+    return fromChoice?.();
   }
 
   // Log errors using the Percy logger

--- a/src/inspect.js
+++ b/src/inspect.js
@@ -1,0 +1,42 @@
+import logger from '@percy/logger';
+import migrations from './migrations';
+
+// Tries to detect the installed SDK by checking the current project's CWD. Checks non-dev deps in
+// addition to dev deps even though SDKs should only be installed as dev deps.
+function inspectPackageJSON(info) {
+  try {
+    let pkg = require(`${process.cwd()}/package.json`);
+    let deps = { ...pkg.dependencies, ...pkg.devDependencies };
+
+    for (let [name, version] of Object.entries(deps)) {
+      if (name === '@percy/agent') info.agent = version;
+      let SDK = migrations.find(SDK => SDK.matches(name));
+      if (SDK) info.installed.push(new SDK(name, version));
+    }
+  } catch (error) {
+    let log = logger('migrate:inspect');
+
+    if (error.code === 'MODULE_NOT_FOUND') {
+      log.warn('Could not find package.json in current directory');
+    } else {
+      log.error('Encountered an error inspecting package.json');
+      log.error(error);
+    }
+  }
+}
+
+// Returns an object containing installed SDK information including whether `@percy/agent` was found
+// within the project's direct dependencies.
+export default function inspectDeps() {
+  let info = {
+    agent: null,
+    installed: []
+  };
+
+  // Node projects
+  inspectPackageJSON(info);
+
+  // @todo: other project languages?
+
+  return info;
+}

--- a/src/migrations/base.js
+++ b/src/migrations/base.js
@@ -1,0 +1,45 @@
+// import semver from 'semver';
+
+class SDKMigration {
+  static matches(name) {
+    return this.name === name ||
+      this.aliases?.includes(name);
+  }
+
+  static get aliased() {
+    return `${this.name}${(
+      !this.aliases?.length ? ''
+        : ` (${this.aliases.join(', ')})`
+    )}`;
+  }
+
+  constructor(name, version) {
+    if (name) this.installed = { name, version };
+  }
+
+  // get name() {
+  //   return this.constructor.name;
+  // }
+
+  // get aliases() {
+  //   return this.constructor.aliases;
+  // }
+
+  get aliased() {
+    return this.constructor.aliased;
+  }
+
+  // get version() {
+  //   return this.constructor.version;
+  // }
+
+  // get needsUpgrade() {
+  //   return !(
+  //     this.installed &&
+  //     this.installed.name === this.name &&
+  //     semver.subset(this.installed.version, this.version)
+  //   );
+  // }
+}
+
+module.exports = SDKMigration;

--- a/src/migrations/index.js
+++ b/src/migrations/index.js
@@ -1,0 +1,2 @@
+module.exports = [
+];

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,59 @@
+import logger from '@percy/logger/test/helper';
+import mockRequire from 'mock-require';
+import inquirer from 'inquirer';
+
+import SDKMigration from '../src/migrations/base';
+
+export function Migrate(...args) {
+  mockRequire.reRequire('../src/inspect');
+  return mockRequire.reRequire('../src').run(args);
+}
+
+export function mockPackageJSON(pkg) {
+  mockRequire(`${process.cwd()}/package.json`, pkg);
+  return pkg;
+}
+
+export function mockMigrations(migrations) {
+  migrations = migrations.map(def => (
+    class extends SDKMigration {
+      static name = def.name;
+      static version = def.version;
+      static aliases = def.aliases || [];
+      upgrade = def.upgrade || (() => {});
+      transforms = def.transforms || [];
+    }
+  ));
+
+  mockRequire('../src/migrations', migrations);
+  mockRequire.reRequire('../src/migrations');
+  return migrations;
+}
+
+export function mockPrompts(answers) {
+  let prompts = [];
+
+  inquirer.prompt = async questions => {
+    prompts.push(...questions);
+
+    return questions.reduce((result, q) => {
+      let a = answers[q.name];
+      if (typeof a === 'function') a = a(q);
+      return { ...result, [q.name]: a };
+    }, {});
+  };
+
+  return prompts;
+}
+
+// common hooks
+beforeEach(() => {
+  logger.mock();
+});
+
+afterEach(() => {
+  process.removeAllListeners();
+  mockRequire.stopAll();
+});
+
+export { logger };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -11,15 +11,6 @@ describe('@percy/migrate', () => {
     process.removeAllListeners();
   });
 
-  it('works', async () => {
-    await Migrate.run([]);
-
-    expect(logger.stderr).toEqual([]);
-    expect(logger.stdout).toEqual([
-      '[percy] Coming soon\n'
-    ]);
-  });
-
   it('logs errors to the logger and exits', async () => {
     class TestErrorHandling extends Migrate {
       run() { this.error('test error'); }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1161,7 +1161,7 @@ ansi-escapes@^3.1.0:
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
-ansi-escapes@^4.3.0:
+ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.1.tgz#a5c47cc43181f1f38ffd7076837700d395522a61"
   integrity sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==
@@ -1500,6 +1500,11 @@ chalk@^4.0.0, chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chardet@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
+  integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
 chokidar@3.5.1, chokidar@^3.4.0:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
@@ -1542,6 +1547,13 @@ clean-stack@^3.0.0:
   dependencies:
     escape-string-regexp "4.0.0"
 
+cli-cursor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
+  integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
+  dependencies:
+    restore-cursor "^3.1.0"
+
 cli-progress@^3.4.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/cli-progress/-/cli-progress-3.9.0.tgz#25db83447deb812e62d05bac1af9aec5387ef3d4"
@@ -1581,6 +1593,11 @@ cli-ux@^5.2.1:
     supports-color "^7.1.0"
     supports-hyperlinks "^2.1.0"
     tslib "^2.0.0"
+
+cli-width@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
+  integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
 
 cliui@^6.0.0:
   version "6.0.0"
@@ -2181,6 +2198,15 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
+external-editor@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
+  integrity sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==
+  dependencies:
+    chardet "^0.7.0"
+    iconv-lite "^0.4.24"
+    tmp "^0.0.33"
+
 extglob@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
@@ -2233,6 +2259,13 @@ fastq@^1.6.0:
   integrity sha512-AWuv6Ery3pM+dY7LYS8YIaCiQvUaos9OB1RyNgaOWnaX+Tik7Onvcsf8x8c+YtDeT0maYLniBip2hox5KtEXXA==
   dependencies:
     reusify "^1.0.4"
+
+figures@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
+  integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
+  dependencies:
+    escape-string-regexp "^1.0.5"
 
 file-entry-cache@^6.0.0:
   version "6.0.0"
@@ -2408,6 +2441,11 @@ gensync@^1.0.0-beta.1:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
+
+get-caller-file@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
+  integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
 
 get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
@@ -2627,6 +2665,13 @@ hyperlinker@^1.0.0:
   resolved "https://registry.yarnpkg.com/hyperlinker/-/hyperlinker-1.0.0.tgz#23dc9e38a206b208ee49bc2d6c8ef47027df0c0e"
   integrity sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==
 
+iconv-lite@^0.4.24:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
+
 ieee754@^1.1.13:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
@@ -2672,6 +2717,25 @@ inherits@2, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+inquirer@^7.3.3:
+  version "7.3.3"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.3.3.tgz#04d176b2af04afc157a83fd7c100e98ee0aad003"
+  integrity sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.19"
+    mute-stream "0.0.8"
+    run-async "^2.4.0"
+    rxjs "^6.6.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
 
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
@@ -3281,6 +3345,11 @@ micromatch@^4.0.2:
     braces "^3.0.1"
     picomatch "^2.0.5"
 
+mimic-fn@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
+  integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
 minimatch@3.0.4, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -3337,6 +3406,14 @@ mocha@^8.3.0:
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
 
+mock-require@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/mock-require/-/mock-require-3.0.3.tgz#ccd544d9eae81dd576b3f219f69ec867318a1946"
+  integrity sha512-lLzfLHcyc10MKQnNUCv7dMcoY/2Qxd6wJfbqCcVk3LDb8An4hF6ohk5AztrvgKhJCqj36uyzi/p5se+tvyD+Wg==
+  dependencies:
+    get-caller-file "^1.0.2"
+    normalize-path "^2.1.1"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -3351,6 +3428,11 @@ ms@2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+mute-stream@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
+  integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
 nanoid@3.1.20:
   version "3.1.20"
@@ -3543,6 +3625,13 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
+onetime@^5.1.0:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
+  integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
+  dependencies:
+    mimic-fn "^2.1.0"
+
 optionator@^0.9.1:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
@@ -3554,6 +3643,11 @@ optionator@^0.9.1:
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
     word-wrap "^1.2.3"
+
+os-tmpdir@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
+  integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
 p-finally@^1.0.0:
   version "1.0.0"
@@ -4040,6 +4134,14 @@ resolve@^1.10.0, resolve@^1.10.1, resolve@^1.13.1, resolve@^1.17.0:
     is-core-module "^2.1.0"
     path-parse "^1.0.6"
 
+restore-cursor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
+  integrity sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==
+  dependencies:
+    onetime "^5.1.0"
+    signal-exit "^3.0.2"
+
 ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
@@ -4064,12 +4166,24 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+run-async@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
+  integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
+
+rxjs@^6.6.0:
+  version "6.6.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
+  integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
+  dependencies:
+    tslib "^1.9.0"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
@@ -4088,6 +4202,11 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
+"safer-buffer@>= 2.1.2 < 3":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
 "semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
@@ -4103,7 +4222,7 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.2.1, semver@^7.3.2:
+semver@^7.2.1, semver@^7.3.2, semver@^7.3.4:
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
   integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
@@ -4471,6 +4590,18 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
+through@^2.3.6:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
+  dependencies:
+    os-tmpdir "~1.0.2"
+
 tmp@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz#ee434a4e22543082e294ba6201dcc6eafefa2877"
@@ -4525,7 +4656,7 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.9.3:
+tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
## What is this?

When running `@percy/migrate`, we want to automatically detect the installed SDK. We also want to prompt the user to confirm this SDK, and if not correct they can choose from a list of supported SDKs. They should also be able to provide an SDK name argument to skip confirming or selecting an SDK from the list. If, at any point while inspecting their package dependencies, no matter if the selected SDK is uninstalled or unsupported, the command should flow gracefully allowing the user to continue to install `@percy/cli` and migrate their Percy config file.

The basic framework of the command was also laid out with this PR. The `inquirer` package is used to prompt for user input. A base `SDKMigration` class was established for future supported migrations. A few test helpers were added to make testing easier. And some extra commented out pseudo code was included to inspire future PRs with planned functionality.


https://user-images.githubusercontent.com/5005153/107834216-3dba4080-6d5b-11eb-92e1-2e1622277cf9.mov

