### PR TITLE
✨ Prompt to install @percy/cli

### DIFF
--- a/src/inspect.js
+++ b/src/inspect.js
@@ -9,6 +9,7 @@ function inspectPackageJSON(info) {
     let deps = { ...pkg.dependencies, ...pkg.devDependencies };
 
     for (let [name, version] of Object.entries(deps)) {
+      if (name === '@percy/cli') info.cli = version;
       if (name === '@percy/agent') info.agent = version;
       let SDK = migrations.find(SDK => SDK.matches(name));
       if (SDK) info.installed.push(new SDK(name, version));

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,67 @@
+import { existsSync } from 'fs';
+import logger from '@percy/logger';
+import spawn from 'cross-spawn';
+import which from 'which';
+
+// Run a command with the specified args
+export async function run(command, args) {
+  // adjust stdio based on the loglevel
+  let stdio = ['inherit', 'inherit', 'inherit'];
+
+  if (logger.loglevel() === 'silent') {
+    stdio = ['ignore', 'ignore', 'ignore'];
+  } else if (logger.loglevel() === 'warn') {
+    stdio = ['ignore', 'ignore', 'inherit'];
+  }
+
+  // run the command synchronously
+  args = args.filter(Boolean);
+  logger('migrate:run').debug(`Running "${command} ${args.join(' ')}"`);
+  let { status, error } = spawn.sync(which.sync(command), args, { stdio });
+
+  // handle errors
+  if (!error && status) {
+    error = Object.assign(new Error(), {
+      message: `${command} failed with exit code ${status}`,
+      status
+    });
+  }
+
+  if (error) {
+    throw error;
+  }
+}
+
+// Common commands to manage node packages
+export const npm = {
+  // Determine package manager based on lockfile
+  get manager() {
+    let hasYarnLock = existsSync(`${process.cwd()}/yarn.lock`);
+    let hasNpmLock = existsSync(`${process.cwd()}/package-lock.json`);
+
+    if (hasYarnLock && hasNpmLock) {
+      logger('migrate:npm').warn('Found both a yarn.lock and package-lock.json, defaulting to npm');
+    }
+
+    // cache the result so the above check and warning only happen once
+    let result = (hasYarnLock && !hasNpmLock && 'yarn') || 'npm';
+    Object.defineProperty(npm, 'manager', { get: () => result });
+    return result;
+  },
+
+  // Install packages with npm or yarn to dev dependencies by default
+  install(specs, { dev = true } = {}) {
+    return run(npm.manager, {
+      npm: ['install', dev && '--save-dev'].concat(specs),
+      yarn: ['add', dev && '--dev'].concat(specs)
+    }[npm.manager]);
+  },
+
+  // Uninstall packages with npm or yarn
+  uninstall(specs) {
+    return run(npm.manager, {
+      npm: ['uninstall'].concat(specs),
+      yarn: ['remove'].concat(specs)
+    }[npm.manager]);
+  }
+};

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -34,7 +34,7 @@ describe('@percy/migrate - SDK inspection', () => {
   });
 
   it('inspects package.json to guess the installed SDK', async () => {
-    await Migrate();
+    await Migrate('--skip-cli');
 
     expect(prompts[0]).toEqual({
       type: 'confirm',
@@ -53,7 +53,7 @@ describe('@percy/migrate - SDK inspection', () => {
     delete packageJSON.devDependencies['@percy/sdk-test'];
     packageJSON.devDependencies['@percy/sdk-old'] = '1.0.0';
 
-    await Migrate();
+    await Migrate('--skip-cli');
 
     expect(prompts[0]).toEqual({
       type: 'confirm',
@@ -75,7 +75,7 @@ describe('@percy/migrate - SDK inspection', () => {
       get() { throw Object.assign(new Error(), { code: 'MODULE_NOT_FOUND' }); }
     });
 
-    await Migrate();
+    await Migrate('--skip-cli');
 
     expect(logger.stderr).toEqual([
       '[percy] Could not find package.json in current directory\n'
@@ -91,7 +91,7 @@ describe('@percy/migrate - SDK inspection', () => {
       get() { throw new Error('some error'); }
     });
 
-    await Migrate();
+    await Migrate('--skip-cli');
 
     expect(logger.stderr).toEqual([
       '[percy] Encountered an error inspecting package.json\n',
@@ -108,7 +108,7 @@ describe('@percy/migrate - SDK inspection', () => {
       fromChoice: q => q.choices[0].value
     });
 
-    await Migrate();
+    await Migrate('--skip-cli');
 
     expect(prompts[1]).toEqual({
       type: 'list',
@@ -134,7 +134,7 @@ describe('@percy/migrate - SDK inspection', () => {
       fromChoice: q => q.choices[1].value
     });
 
-    await Migrate();
+    await Migrate('--skip-cli');
 
     expect(logger.stderr).toEqual([
       '[percy] The specified SDK was not found in your dependencies\n'
@@ -145,7 +145,7 @@ describe('@percy/migrate - SDK inspection', () => {
   });
 
   it('allows specifying an SDK directly', async () => {
-    await Migrate('@percy/sdk-test');
+    await Migrate('@percy/sdk-test', '--skip-cli');
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
@@ -160,7 +160,7 @@ describe('@percy/migrate - SDK inspection', () => {
       }
     });
 
-    await Migrate('@percy/sdk-old');
+    await Migrate('@percy/sdk-old', '--skip-cli');
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
@@ -169,7 +169,7 @@ describe('@percy/migrate - SDK inspection', () => {
   });
 
   it('warns when the specified SDK is not supported', async () => {
-    await Migrate('@percy/sdk-test-3');
+    await Migrate('@percy/sdk-test-3', '--skip-cli');
 
     expect(logger.stderr).toEqual([
       '[percy] The specified SDK is not supported\n'
@@ -180,7 +180,7 @@ describe('@percy/migrate - SDK inspection', () => {
   });
 
   it('warns when the specified SDK is not installed', async () => {
-    await Migrate('@percy/sdk-test-2');
+    await Migrate('@percy/sdk-test-2', '--skip-cli');
 
     expect(logger.stderr).toEqual([
       '[percy] The specified SDK was not found in your dependencies\n'

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -1,0 +1,175 @@
+import expect from 'expect';
+import mockRequire from 'mock-require';
+import {
+  Migrate,
+  logger,
+  mockPackageJSON,
+  mockCommands,
+  mockPrompts
+} from './helpers';
+
+describe('@percy/migrate - CLI install', () => {
+  let packageJSON, prompts, run;
+
+  beforeEach(() => {
+    packageJSON = mockPackageJSON({});
+
+    prompts = mockPrompts({
+      installCLI: true
+    });
+
+    run = mockCommands({
+      npm: () => ({ status: 0 }),
+      yarn: () => ({ status: 0 })
+    });
+
+    mockRequire('fs', {
+      existsSync: path => path.endsWith('package-lock.json')
+    });
+  });
+
+  it('confirms the CLI installation', async () => {
+    await Migrate('--only-cli');
+
+    expect(prompts[0]).toEqual({
+      type: 'confirm',
+      name: 'installCLI',
+      message: 'Install @percy/cli?',
+      default: true
+    });
+
+    expect(run.npm.calls[0].args)
+      .toEqual(['install', '--save-dev', '@percy/cli']);
+
+    expect(logger.stderr).toEqual([]);
+    expect(logger.stdout).toEqual([
+      expect.stringMatching('See further migration instructions here:')
+    ]);
+  });
+
+  it('does not install the CLI when not confirmed', async () => {
+    prompts = mockPrompts({
+      installCLI: false
+    });
+
+    await Migrate('--only-cli');
+
+    expect(prompts[0]).toEqual({
+      type: 'confirm',
+      name: 'installCLI',
+      message: 'Install @percy/cli?',
+      default: true
+    });
+
+    expect(run.npm.calls).toBeUndefined();
+
+    expect(logger.stderr).toEqual([]);
+    expect(logger.stdout).toEqual([
+      expect.stringMatching('See further migration instructions here:')
+    ]);
+  });
+
+  it('does not confirm when the CLI is already installed', async () => {
+    packageJSON.devDependencies = { '@percy/cli': '^1.0.0' };
+    await Migrate('--only-cli');
+
+    expect(prompts[0]).toBeUndefined();
+    expect(run.npm.calls).toBeUndefined();
+
+    expect(logger.stderr).toEqual([]);
+    expect(logger.stdout).toEqual([
+      expect.stringMatching('See further migration instructions here:')
+    ]);
+  });
+
+  it('removes @percy/agent when necessary', async () => {
+    packageJSON.devDependencies = { '@percy/agent': '^0.1.0' };
+    await Migrate('--only-cli');
+
+    expect(prompts[0]).toEqual({
+      type: 'confirm',
+      name: 'installCLI',
+      message: 'Install @percy/cli (and remove @percy/agent)?',
+      default: true
+    });
+
+    expect(run.npm.calls[0].args)
+      .toEqual(['uninstall', '@percy/agent']);
+    expect(run.npm.calls[1].args)
+      .toEqual(['install', '--save-dev', '@percy/cli']);
+
+    expect(logger.stderr).toEqual([]);
+    expect(logger.stdout).toEqual([
+      expect.stringMatching('See further migration instructions here:')
+    ]);
+  });
+
+  it('uses yarn when a yarn.lock exists', async () => {
+    packageJSON.devDependencies = { '@percy/agent': '^0.1.0' };
+    mockRequire('fs', { existsSync: path => path.endsWith('yarn.lock') });
+    await Migrate('--only-cli');
+
+    expect(run.yarn.calls[0].args)
+      .toEqual(['remove', '@percy/agent']);
+    expect(run.yarn.calls[1].args)
+      .toEqual(['add', '--dev', '@percy/cli']);
+
+    expect(logger.stderr).toEqual([]);
+    expect(logger.stdout).toEqual([
+      expect.stringMatching('See further migration instructions here:')
+    ]);
+  });
+
+  it('warns and uses npm when both a yarn.lock and package-lock.json exists', async () => {
+    mockRequire('fs', { existsSync: () => true });
+    await Migrate('--only-cli');
+
+    expect(run.npm.calls[0].args)
+      .toEqual(['install', '--save-dev', '@percy/cli']);
+
+    expect(logger.stderr).toEqual([
+      '[percy] Found both a yarn.lock and package-lock.json, defaulting to npm\n'
+    ]);
+    expect(logger.stdout).toEqual([
+      expect.stringMatching('See further migration instructions here:')
+    ]);
+  });
+
+  it('runs with the appropriate stdio values', async () => {
+    await Migrate('--only-cli');
+
+    expect(run.npm.calls[0].options)
+      .toEqual({ stdio: ['inherit', 'inherit', 'inherit'] });
+  });
+
+  it('runs with the appropriate stdio values when quiet', async () => {
+    await Migrate('--only-cli', '--quiet');
+
+    expect(run.npm.calls[0].options)
+      .toEqual({ stdio: ['ignore', 'ignore', 'inherit'] });
+  });
+
+  it('runs with the appropriate stdio values when silent', async () => {
+    await Migrate('--only-cli', '--silent');
+
+    expect(run.npm.calls[0].options)
+      .toEqual({ stdio: ['ignore', 'ignore', 'ignore'] });
+  });
+
+  it('exits when the subcommand fails', async () => {
+    run = mockCommands({
+      npm: () => ({ status: 3 })
+    });
+
+    await expect(Migrate('--only-cli'))
+      .rejects.toThrow('EEXIT: 3');
+
+    expect(run.npm.calls[0].args)
+      .toEqual(['install', '--save-dev', '@percy/cli']);
+
+    expect(logger.stdout).toEqual([]);
+    expect(logger.stderr).toEqual([
+      '[percy] Error: npm failed with exit code 3\n'
+    ]);
+  });
+});


### PR DESCRIPTION
## What is this?

This adds the step to the migration tool in which it will prompt the user to install `@percy/cli` if not already installed. If `@percy/agent` is present, it will also be uninstalled.

A utility was created which normalizes install/uninstall steps using either npm or yarn depending on the presence of their respective lock files. This utility can be used in future SDK migration steps to upgrade SDK packages. The run function was also extracted into a generalized util so it can also be used in future steps unrelated to node packages (such as running codemods).

Flags were added to the command mostly to make testing easier, but also might be useful for users to skip prompting questions. `--only-cli` will only prompt for CLI related steps such as this install step and a future config migration step. `--skip-cli` will only prompt for SDK related steps. 

Additional test helpers were also created to make testing the `run` helper easier