### PR TITLE
✨ Prompt to run SDK upgrade

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ class Migrate extends Command {
 
     // perform sdk migration
     if (sdk) {
-      // await this.confirmUpgrade(sdk);
+      await this.confirmUpgrade(sdk);
       // await this.confirmTransforms(sdk);
       this.log.info('Migration complete!');
     } else {
@@ -161,6 +161,22 @@ class Migrate extends Command {
     }]);
 
     return fromChoice?.();
+  }
+
+  // Confirms if the SDK needs an upgrade and performs the upgrade
+  async confirmUpgrade(sdk) {
+    if (!sdk.needsUpgrade) return;
+
+    let { upgradeSDK } = await inquirer.prompt([{
+      type: 'confirm',
+      name: 'upgradeSDK',
+      message: `Upgrade SDK to ${sdk.name}@${sdk.version}?`,
+      default: true
+    }]);
+
+    if (upgradeSDK) {
+      await sdk.upgrade();
+    }
   }
 
   // Log errors using the Percy logger

--- a/src/migrations/base.js
+++ b/src/migrations/base.js
@@ -1,4 +1,4 @@
-// import semver from 'semver';
+import semver from 'semver';
 
 class SDKMigration {
   static matches(name) {
@@ -17,9 +17,9 @@ class SDKMigration {
     if (name) this.installed = { name, version };
   }
 
-  // get name() {
-  //   return this.constructor.name;
-  // }
+  get name() {
+    return this.constructor.name;
+  }
 
   // get aliases() {
   //   return this.constructor.aliases;
@@ -29,17 +29,17 @@ class SDKMigration {
     return this.constructor.aliased;
   }
 
-  // get version() {
-  //   return this.constructor.version;
-  // }
+  get version() {
+    return this.constructor.version;
+  }
 
-  // get needsUpgrade() {
-  //   return !(
-  //     this.installed &&
-  //     this.installed.name === this.name &&
-  //     semver.subset(this.installed.version, this.version)
-  //   );
-  // }
+  get needsUpgrade() {
+    return !(
+      this.installed &&
+      this.installed.name === this.name &&
+      semver.subset(this.installed.version, this.version)
+    );
+  }
 }
 
 module.exports = SDKMigration;


### PR DESCRIPTION
## What is this?

This adds the step in which the user is prompted to upgrade their SDK if needed. When confirmed, the SDK migration class instance's `upgrade` method will be called. In the future, specific SDKs can use this method to call on npm or the run util to upgrade the package.