### PR TITLE
✨ Prompt for config migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@oclif/command": "^1.8.0",
     "@oclif/config": "^1.17.0",
     "@oclif/plugin-help": "^3.2.0",
-    "@percy/cli-config": "^1.0.0-beta.35",
+    "@percy/config": "^1.0.0-beta.35",
     "@percy/logger": "^1.0.0-beta.35",
     "cross-spawn": "^7.0.3",
     "globby": "^11.0.2",

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,0 +1,89 @@
+import expect from 'expect';
+import {
+  Migrate,
+  logger,
+  mockPrompts,
+  mockCommands,
+  mockPackageJSON,
+  mockConfigSearch
+} from './helpers';
+
+describe('@percy/migrate - Config migration', () => {
+  let migrated, prompts;
+
+  beforeEach(() => {
+    migrated = false;
+    mockPackageJSON({});
+
+    prompts = mockPrompts({
+      doConfig: true
+    });
+
+    mockCommands({
+      npm: () => ({ status: 0 }),
+      yarn: () => ({ status: 0 }),
+      [`${process.cwd()}/node_modules/@percy/cli/bin/run`]: args => {
+        migrated = args[0] === 'config:migrate';
+        return { status: 0 };
+      }
+    });
+  });
+
+  it('confirms config migration', async () => {
+    await Migrate('--only-cli');
+
+    expect(prompts[1]).toEqual({
+      type: 'confirm',
+      name: 'doConfig',
+      message: 'Migrate Percy config file?',
+      default: true
+    });
+
+    expect(migrated).toBe(true);
+
+    expect(logger.stderr).toEqual([]);
+    expect(logger.stdout).toEqual([
+      expect.stringMatching('See further migration instructions here:')
+    ]);
+  });
+
+  it('does not migrate config when not confirmed', async () => {
+    mockPrompts({ doConfig: false });
+    await Migrate('--only-cli');
+
+    expect(migrated).toBe(false);
+
+    expect(logger.stderr).toEqual([]);
+    expect(logger.stdout).toEqual([
+      expect.stringMatching('See further migration instructions here:')
+    ]);
+  });
+
+  it('Does not prompt when no config file was found', async () => {
+    mockConfigSearch(() => false);
+    await Migrate('--only-cli');
+
+    expect(prompts[1]).toBeUndefined();
+    expect(migrated).toBe(false);
+
+    expect(logger.stderr).toEqual([]);
+    expect(logger.stdout).toEqual([
+      expect.stringMatching('See further migration instructions here:')
+    ]);
+  });
+
+  it('Logs an error when the config file fails to parse', async () => {
+    mockConfigSearch(() => { throw new Error('config parse failure'); });
+    await Migrate('--only-cli');
+
+    expect(migrated).toBe(false);
+
+    expect(logger.stderr).toEqual([
+      '[percy] Failed to load or parse config file\n',
+      '[percy] Error: config parse failure\n'
+    ]);
+    expect(logger.stdout).toEqual([
+      expect.stringMatching('See further migration instructions here:')
+    ]);
+  });
+});

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -17,6 +17,12 @@ export function mockPackageJSON(pkg) {
   return pkg;
 }
 
+export function mockConfigSearch(search) {
+  mockRequire('cosmiconfig', { cosmiconfigSync: () => ({ search }) });
+  mockRequire.reRequire('@percy/config/dist/load');
+  mockRequire.reRequire('@percy/config');
+}
+
 export function mockMigrations(migrations) {
   migrations = migrations.map(def => (
     class extends SDKMigration {
@@ -74,6 +80,7 @@ export function mockPrompts(answers) {
 // common hooks
 beforeEach(() => {
   logger.mock();
+  mockConfigSearch(() => ({ config: {} }));
   mockCommands({
     npm: () => ({ status: 0 }),
     yarn: () => ({ status: 0 })

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -73,7 +73,7 @@ describe('@percy/migrate - CLI install', () => {
     packageJSON.devDependencies = { '@percy/cli': '^1.0.0' };
     await Migrate('--only-cli');
 
-    expect(prompts[0]).toBeUndefined();
+    expect(prompts[0].name).not.toEqual('installCLI');
     expect(run.npm.calls).toBeUndefined();
 
     expect(logger.stderr).toEqual([]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1085,16 +1085,6 @@
   resolved "https://registry.yarnpkg.com/@oclif/screen/-/screen-1.0.4.tgz#b740f68609dfae8aa71c3a6cab15d816407ba493"
   integrity sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw==
 
-"@percy/cli-config@^1.0.0-beta.35":
-  version "1.0.0-beta.35"
-  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.0.0-beta.35.tgz#3546e045824288f181174141e7ba4f61b4308d64"
-  integrity sha512-VQ6v9hlKFsQ36WXUWpHHE7hQ2fNf14hDNomfVIVOcT93zIi/iRds8CtB6lX2LVtBmdG2vDuoR3f4se3N4Qv5KQ==
-  dependencies:
-    "@oclif/command" "^1.8.0"
-    "@oclif/config" "^1.17.0"
-    "@percy/config" "^1.0.0-beta.35"
-    "@percy/logger" "^1.0.0-beta.35"
-
 "@percy/config@^1.0.0-beta.35":
   version "1.0.0-beta.35"
   resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.0.0-beta.35.tgz#28920b24366c1d18b61849dc3ce38c1ad1bb9d1c"


### PR DESCRIPTION
## What is this?

This adds the step in which users are prompted to migrate their config if detected. It uses the PercyConfig explorer directly to detect a config file and if there is no config file, the user will not be prompted. When running the migrate command, the CLI is run as a subprocess instead of being called programmatically to utilize the locally installed CLI and its registered plugins.