### PR TITLE
✨ Allow migrations of various languages

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,7 @@ class Migrate extends Command {
 
     // get the desired sdk migration
     let sdk = !this.flags['only-cli'] &&
-      await this.confirmSDK(this.args.sdk_name, info.installed);
+      await this.confirmSDK(info, this.args.sdk_name);
 
     // install @percy/cli and migrate config
     if (!this.flags['skip-cli']) {
@@ -133,12 +133,16 @@ class Migrate extends Command {
 
   // Confirms if the first SDK in the list is the current SDK, otherwise will present a list of
   // supported SDKs to choose from, erroring when the chosen SDK is not in the list
-  async confirmSDK(name, installed) {
+  async confirmSDK({ installed, inspected }, name) {
     let sdk;
 
     let fromInstalled = SDK => {
       let sdk = installed.find(sdk => sdk instanceof SDK) || new SDK();
-      if (!sdk.installed) this.log.warn('The specified SDK was not found in your dependencies');
+
+      if (!sdk.installed && inspected.includes(sdk.language)) {
+        this.log.warn('The specified SDK was not found in your dependencies');
+      }
+
       return sdk;
     };
 

--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,7 @@ class Migrate extends Command {
     }
 
     // perform sdk migration
-    if (sdk) {
+    if (sdk?.upgrade) {
       await this.confirmUpgrade(sdk);
       await this.confirmTransforms(sdk);
       this.log.info('Migration complete!');

--- a/src/inspect.js
+++ b/src/inspect.js
@@ -11,8 +11,8 @@ function inspectPackageJSON(info) {
     for (let [name, version] of Object.entries(deps)) {
       if (name === '@percy/cli') info.cli = version;
       if (name === '@percy/agent') info.agent = version;
-      let SDK = migrations.find(SDK => SDK.matches(name));
-      if (SDK) info.installed.push(new SDK(name, version));
+      let SDK = migrations.find(SDK => SDK.matches(name, 'js'));
+      if (SDK) info.installed.push(new SDK({ name, version }));
     }
   } catch (error) {
     let log = logger('migrate:inspect');

--- a/src/inspect.js
+++ b/src/inspect.js
@@ -14,6 +14,8 @@ function inspectPackageJSON(info) {
       let SDK = migrations.find(SDK => SDK.matches(name, 'js'));
       if (SDK) info.installed.push(new SDK({ name, version }));
     }
+
+    info.inspected.push('js');
   } catch (error) {
     let log = logger('migrate:inspect');
 
@@ -31,10 +33,11 @@ function inspectPackageJSON(info) {
 export default function inspectDeps() {
   let info = {
     agent: null,
-    installed: []
+    installed: [],
+    inspected: []
   };
 
-  // Node projects
+  // JS projects
   inspectPackageJSON(info);
 
   // @todo: other project languages?

--- a/src/migrations/base.js
+++ b/src/migrations/base.js
@@ -1,11 +1,16 @@
 import semver from 'semver';
 
 class SDKMigration {
-  static matches(name) {
-    return this.name === name ||
-      this.aliases?.includes(name);
+  // default SDK language
+  static language = 'js';
+
+  // returns true for the same language and matching name/alias
+  static matches(name, lang) {
+    return (!lang || this.language === lang) &&
+      (this.name === name || this.aliases?.includes(name));
   }
 
+  // returns a formated string matching "{name} ({aliases})"
   static get aliased() {
     return `${this.name}${(
       !this.aliases?.length ? ''
@@ -13,8 +18,9 @@ class SDKMigration {
     )}`;
   }
 
-  constructor(name, version) {
-    if (name) this.installed = { name, version };
+  // initialized with the installed SDK info
+  constructor(installed) {
+    this.installed = installed;
     this.transforms = [];
   }
 
@@ -34,6 +40,8 @@ class SDKMigration {
     return this.constructor.version;
   }
 
+  // returns true if the SDK is not installed or if the installed SDK has
+  // a different name or version subset
   get needsUpgrade() {
     return !(
       this.installed &&

--- a/src/migrations/base.js
+++ b/src/migrations/base.js
@@ -24,6 +24,10 @@ class SDKMigration {
     this.transforms = [];
   }
 
+  get language() {
+    return this.constructor.language;
+  }
+
   get name() {
     return this.constructor.name;
   }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -27,9 +27,10 @@ export function mockMigrations(migrations) {
     class extends SDKMigration {
       static name = def.name;
       static version = def.version;
-      static aliases = def.aliases || [];
-      upgrade = def.upgrade || (() => {});
-      transforms = def.transforms || [];
+      static language = def.language ?? 'js';
+      static aliases = def.aliases ?? [];
+      upgrade = def.upgrade ?? (() => {});
+      transforms = def.transforms ?? [];
     }
   ));
 

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -190,6 +190,21 @@ describe('@percy/migrate - SDK inspection', () => {
     ]);
   });
 
+  it('does not warn on uninstalled if the language was not inspected', async () => {
+    mockMigrations([{
+      language: 'coldfusion',
+      name: 'some-ancient-sdk',
+      version: '^1.0.0'
+    }]);
+
+    await Migrate('some-ancient-sdk', '--skip-cli');
+
+    expect(logger.stderr).toEqual([]);
+    expect(logger.stdout).toEqual([
+      '[percy] Migration complete!\n'
+    ]);
+  });
+
   it('prints further instructions when the SDK cannot be upgraded', async () => {
     mockMigrations([{
       name: '@percy/sdk-test',

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -189,4 +189,19 @@ describe('@percy/migrate - SDK inspection', () => {
       '[percy] Migration complete!\n'
     ]);
   });
+
+  it('prints further instructions when the SDK cannot be upgraded', async () => {
+    mockMigrations([{
+      name: '@percy/sdk-test',
+      version: '^2.0.0',
+      upgrade: false
+    }]);
+
+    await Migrate('@percy/sdk-test', '--skip-cli');
+
+    expect(logger.stderr).toEqual([]);
+    expect(logger.stdout).toEqual([
+      expect.stringMatching('See further migration instructions here:')
+    ]);
+  });
 });

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -29,7 +29,7 @@ describe('@percy/migrate - SDK inspection', () => {
     });
 
     prompts = mockPrompts({
-      isGuess: true
+      isSDK: true
     });
   });
 
@@ -38,7 +38,7 @@ describe('@percy/migrate - SDK inspection', () => {
 
     expect(prompts[0]).toEqual({
       type: 'confirm',
-      name: 'isGuess',
+      name: 'isSDK',
       message: 'Are you currently using @percy/sdk-test?',
       default: true
     });
@@ -57,7 +57,7 @@ describe('@percy/migrate - SDK inspection', () => {
 
     expect(prompts[0]).toEqual({
       type: 'confirm',
-      name: 'isGuess',
+      name: 'isSDK',
       message: 'Are you currently using @percy/sdk-test-2 (@percy/sdk-old)?',
       default: true
     });
@@ -104,7 +104,7 @@ describe('@percy/migrate - SDK inspection', () => {
 
   it('allows choosing from supported SDKs', async () => {
     prompts = mockPrompts({
-      isGuess: false,
+      isSDK: false,
       fromChoice: q => q.choices[0].value
     });
 
@@ -130,7 +130,7 @@ describe('@percy/migrate - SDK inspection', () => {
 
   it('warns when the selected SDK is not installed', async () => {
     prompts = mockPrompts({
-      isGuess: false,
+      isSDK: false,
       fromChoice: q => q.choices[1].value
     });
 

--- a/test/transforms.test.js
+++ b/test/transforms.test.js
@@ -34,6 +34,7 @@ describe('@percy/migrate - SDK transforms', () => {
     });
 
     prompts = mockPrompts({
+      isSDK: true,
       doTransform: false
     });
   });
@@ -41,14 +42,14 @@ describe('@percy/migrate - SDK transforms', () => {
   it('confirms any SDK transforms', async () => {
     await Migrate('@percy/sdk-test', '--skip-cli');
 
-    expect(prompts[1]).toEqual({
+    expect(prompts[2]).toEqual({
       type: 'confirm',
       name: 'doTransform',
       message: 'Run this transform?',
       default: true
     });
 
-    expect(prompts[2]).toEqual({
+    expect(prompts[3]).toEqual({
       type: 'confirm',
       name: 'doTransform',
       message: 'How about this one?',
@@ -63,13 +64,14 @@ describe('@percy/migrate - SDK transforms', () => {
 
   it('asks for filepaths to transform when confirmed', async () => {
     prompts = mockPrompts({
+      isSDK: true,
       doTransform: true,
       filePaths: q => q.filter(q.default)
     });
 
     await Migrate('@percy/sdk-test', '--skip-cli');
 
-    expect(prompts[2]).toEqual({
+    expect(prompts[3]).toEqual({
       type: 'input',
       name: 'filePaths',
       message: 'Which files?',
@@ -77,7 +79,7 @@ describe('@percy/migrate - SDK transforms', () => {
       filter: expect.any(Function)
     });
 
-    expect(prompts[4]).toEqual({
+    expect(prompts[5]).toEqual({
       type: 'input',
       name: 'filePaths',
       message: 'Which files?',

--- a/test/upgrade.test.js
+++ b/test/upgrade.test.js
@@ -27,6 +27,7 @@ describe('@percy/migrate - SDK upgrade', () => {
     });
 
     prompts = mockPrompts({
+      isSDK: true,
       upgradeSDK: true
     });
   });
@@ -35,7 +36,7 @@ describe('@percy/migrate - SDK upgrade', () => {
     await Migrate('@percy/sdk-test', '--skip-cli');
 
     expect(upgraded).toBe(true);
-    expect(prompts[0]).toEqual({
+    expect(prompts[1]).toEqual({
       type: 'confirm',
       name: 'upgradeSDK',
       message: 'Upgrade SDK to @percy/sdk-test@^2.0.0?',
@@ -52,7 +53,7 @@ describe('@percy/migrate - SDK upgrade', () => {
     await Migrate('@percy/sdk-old', '--skip-cli');
 
     expect(upgraded).toBe(true);
-    expect(prompts[0]).toEqual({
+    expect(prompts[1]).toEqual({
       type: 'confirm',
       name: 'upgradeSDK',
       message: 'Upgrade SDK to @percy/sdk-test@^2.0.0?',
@@ -67,13 +68,14 @@ describe('@percy/migrate - SDK upgrade', () => {
 
   it('does not upgrade when not confirmed', async () => {
     prompts = mockPrompts({
+      isSDK: true,
       upgrade: false
     });
 
     await Migrate('@percy/sdk-test', '--skip-cli');
 
     expect(upgraded).toBe(false);
-    expect(prompts[0]).toEqual({
+    expect(prompts[1]).toEqual({
       type: 'confirm',
       name: 'upgradeSDK',
       message: 'Upgrade SDK to @percy/sdk-test@^2.0.0?',
@@ -96,7 +98,7 @@ describe('@percy/migrate - SDK upgrade', () => {
     await Migrate('@percy/sdk-test', '--skip-cli');
 
     expect(upgraded).toBe(false);
-    expect(prompts).toEqual([]);
+    expect(prompts[1]).toBeUndefined();
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
@@ -108,7 +110,7 @@ describe('@percy/migrate - SDK upgrade', () => {
     await Migrate('@percy/sdk-test-2', '--skip-cli');
 
     expect(upgraded).toBe(false);
-    expect(prompts).toEqual([]);
+    expect(prompts[1]).toBeUndefined();
 
     expect(logger.stderr).toEqual([
       '[percy] The specified SDK is not supported\n'


### PR DESCRIPTION
## What is this?

The new CLI is backwards compatible with SDKs that do not require `@percy/agent` directly. These SDKs can be upgraded by simply installing the CLI and uninstalling `@percy/agent`. There are deprecation warnings, so these SDKs should still be upgraded in the future. However, to support the migration of SDKs in other languages some changes had to be made.

First, the base migration class has a default language of `js` since that is our most common SDK language. However, in the next iteration of SDKs, some package names my match across languages (e.g. `percy-selenium` for Java/Python/Ruby). So a new check was added to the match method in which the language is also considered. 

When providing an SDK name directly, the language cannot be inferred. So the first matching SDK will be selected. Rather than continue with a potentially wrong SDK, the user will now _always_ be prompted to confirm their SDK, even if one is provided to the CLI command.

Finally, a warning would be printed if the confirmed SDK was not found in the project's dependencies. However, we do not inspect dependencies of other languages (yet), so this warning can be confusing if the SDK is indeed included in the project dependencies. This has been updated to take the language into consideration by adding an `inspected` property to the returned object from `inspect`. If the selected SDK's language was not inspected, the warning is not logged.

In addition to alternate language support, a line was also changed (and a test added) to support migrations that do not define an upgrade path. These migrations will skip the upgrade path and print the link to the migration doc.