### PR TITLE
✨ Add initial non-js SDK migrations

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,6 +85,7 @@ class Migrate extends Command {
       await this.confirmTransforms(sdk);
       this.log.info('Migration complete!');
     } else {
+      if (sdk) this.log.warn('Make sure your SDK is upgraded to the latest version!');
       this.log.info('See further migration instructions here: ' + (
         'https://docs.percy.io/docs/migrating-to-percy-cli'));
     }

--- a/src/migrations/capybara.js
+++ b/src/migrations/capybara.js
@@ -1,0 +1,9 @@
+import SDKMigration from './base';
+
+class CapybaraMigration extends SDKMigration {
+  static language = 'ruby';
+  static name = 'percy-capybara';
+  static version = '^5.0.0';
+};
+
+module.exports = CapybaraMigration;

--- a/src/migrations/index.js
+++ b/src/migrations/index.js
@@ -1,2 +1,5 @@
 module.exports = [
+  require('./capybara'),
+  require('./selenium-java'),
+  require('./selenium-python')
 ];

--- a/src/migrations/selenium-java.js
+++ b/src/migrations/selenium-java.js
@@ -1,0 +1,10 @@
+import SDKMigration from './base';
+
+class SeleniumJavaMigration extends SDKMigration {
+  static language = 'java';
+  static name = 'percy-selenium';
+  static aliases = ['percy-java-selenium'];
+  static version = '^1.0.0';
+};
+
+module.exports = SeleniumJavaMigration;

--- a/src/migrations/selenium-python.js
+++ b/src/migrations/selenium-python.js
@@ -1,0 +1,10 @@
+import SDKMigration from './base';
+
+class SeleniumPythonMigration extends SDKMigration {
+  static language = 'python';
+  static name = 'percy-selenium';
+  static aliases = ['percy-python-selenium'];
+  static version = '^1.0.0';
+};
+
+module.exports = SeleniumPythonMigration;

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -214,7 +214,9 @@ describe('@percy/migrate - SDK inspection', () => {
 
     await Migrate('@percy/sdk-test', '--skip-cli');
 
-    expect(logger.stderr).toEqual([]);
+    expect(logger.stderr).toEqual([
+      '[percy] Make sure your SDK is upgraded to the latest version!\n'
+    ]);
     expect(logger.stdout).toEqual([
       expect.stringMatching('See further migration instructions here:')
     ]);


### PR DESCRIPTION
## What is this?

Add initial migrations for `percy-python-selenium`, `percy-java-selenium`, and `percy-capybara`. These initial migrations do not upgrade the SDK, but will install the CLI and remove agent while printing a link to the migration doc.

I also added a warning to upgrade the SDK if the SDK does not have an upgrade path.