### PR TITLE
♻ Update non-js SDK warn to include SDK version

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,11 @@ class Migrate extends Command {
       await this.confirmTransforms(sdk);
       this.log.info('Migration complete!');
     } else {
-      if (sdk) this.log.warn('Make sure your SDK is upgraded to the latest version!');
+      if (sdk) {
+        this.log.warn(
+          `Make sure your SDK is upgraded to the latest version (${sdk.name} ${sdk.version})!`
+        );
+      }
       this.log.info('See further migration instructions here: ' + (
         'https://docs.percy.io/docs/migrating-to-percy-cli'));
     }

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -129,7 +129,7 @@ describe('SDK inspection', () => {
     await Migrate('@percy/sdk-test', '--skip-cli');
 
     expect(logger.stderr).toEqual([
-      '[percy] Make sure your SDK is upgraded to the latest version!\n'
+      '[percy] Make sure your SDK is upgraded to the latest version (@percy/sdk-test ^2.0.0)!\n'
     ]);
     expect(logger.stdout).toEqual([
       expect.stringMatching('See further migration instructions here:')


### PR DESCRIPTION
## What is this?

This adds the SDK version to the warning that's logged for non-js SDKs. This is to make sure the user has upgraded their SDK in their languages dependency manager (like `mvn` or `pip`). 

![image](https://user-images.githubusercontent.com/2072894/108915857-1a14b700-75f3-11eb-9c93-fae724046f56.png)
