### PR TITLE
🐛 Allow transforms when an SDK is not installed

### DIFF
--- a/src/migrations/puppeteer.js
+++ b/src/migrations/puppeteer.js
@@ -16,7 +16,7 @@ class PuppeteerMigration extends SDKMigration {
     async transform(paths) {
       await run(require.resolve('jscodeshift/bin/jscodeshift'), [
         `--transform=${path.resolve(__dirname, '../../transforms/import-default.js')}`,
-        `--percy-installed=${this.installed.name}`,
+        this.installed && `--percy-installed=${this.installed.name}`,
         `--percy-sdk=${this.name}`,
         ...paths
       ]);

--- a/test/helpers/setup-migration.js
+++ b/test/helpers/setup-migration.js
@@ -5,7 +5,7 @@ import mockCommands from './mock-commands';
 
 // Setup a migration test by mocking package.json, sdk prompts, and upgrade commands
 export default function setupMigrationTest(filename, mocks) {
-  mockPackageJSON({
+  let packageJSON = mockPackageJSON({
     devDependencies: {
       [require(`../../src/migrations/${filename}`).name]: '0.0.0'
     }
@@ -33,5 +33,5 @@ export default function setupMigrationTest(filename, mocks) {
   mockRequire.reRequire(`../../src/migrations/${filename}`);
   mockRequire.reRequire('../../src/migrations');
 
-  return [prompts, run];
+  return { packageJSON, prompts, run };
 }

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -73,7 +73,7 @@ describe('CLI installation', () => {
     packageJSON.devDependencies = { '@percy/cli': '^1.0.0' };
     await Migrate('--only-cli');
 
-    expect(prompts[0].name).not.toEqual('installCLI');
+    expect(prompts).not.toHaveProperty('0.name', 'installCLI');
     expect(run.npm.calls).toBeUndefined();
 
     expect(logger.stderr).toEqual([]);

--- a/test/migrations/puppeteer.test.js
+++ b/test/migrations/puppeteer.test.js
@@ -57,4 +57,30 @@ describe('Migrations - @percy/puppeteer', () => {
       '[percy] Migration complete!\n'
     ]);
   });
+
+  it('asks to transform sdk imports even when not installed', async () => {
+    delete packageJSON.devDependencies;
+
+    await Migrate('@percy/puppeteer', '--skip-cli');
+
+    expect(prompts[2]).toEqual({
+      type: 'confirm',
+      name: 'doTransform',
+      message: 'SDK exports have changed, update imports?',
+      default: true
+    });
+
+    expect(run[jscodeshiftbin].calls[0].args).toEqual([
+      `--transform=${require.resolve('../../transforms/import-default')}`,
+      '--percy-sdk=@percy/puppeteer',
+      ...(await globby('test/**/*.test.js').then(f => f.sort()))
+    ]);
+
+    expect(logger.stderr).toEqual([
+      '[percy] The specified SDK was not found in your dependencies\n'
+    ]);
+    expect(logger.stdout).toEqual([
+      '[percy] Migration complete!\n'
+    ]);
+  });
 });

--- a/test/migrations/puppeteer.test.js
+++ b/test/migrations/puppeteer.test.js
@@ -8,14 +8,12 @@ import {
 
 describe('Migrations - @percy/puppeteer', () => {
   let jscodeshiftbin = require.resolve('jscodeshift/bin/jscodeshift');
-  let prompts, run;
+  let packageJSON, prompts, run;
 
   beforeEach(() => {
-    [prompts, run] = setupMigrationTest('puppeteer', {
-      mockCommands: {
-        [jscodeshiftbin]: () => ({ status: 0 })
-      }
-    });
+    ({ packageJSON, prompts, run } = setupMigrationTest('puppeteer', {
+      mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) }
+    }));
   });
 
   it('upgrades the sdk', async () => {


### PR DESCRIPTION
## What is this?

If an SDK is not installed, the `installed` property of the instance is not defined. When the Puppeteer migration runs its transforms, it provides the import transform with the installed SDKs name. This will throw an error when invoked since `name` does not exist on the undefined property. Since this option is not required for the transform, we can omit it entirely when the SDK is not installed.