### PR TITLE
🐛 Warn when @percy/cli is missing during config migration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import { existsSync } from 'fs';
 import Command, { flags } from '@oclif/command';
 import PercyConfig from '@percy/config';
 import logger from '@percy/logger';
@@ -128,7 +129,12 @@ class Migrate extends Command {
 
     if (doConfig) {
       let percybin = `${process.cwd()}/node_modules/@percy/cli/bin/run`;
-      await run(percybin, ['config:migrate']);
+
+      if (!existsSync(percybin)) {
+        this.log.warn('Could not run config migration, @percy/cli is not installed');
+      } else {
+        await run(percybin, ['config:migrate']);
+      }
     }
   }
 


### PR DESCRIPTION
## What is this?

If the user opts to skip the CLI install, or if the CLI is detected in the project dependencies but not actually installed to node_modules yet, this migration tool will error and exit at the config migration step.

This PR fixes that by first checking for the existence of the binary. It will print a warning and continue to other steps when the CLI binary is not found. 

In the future, we might want to think about also checking for a globally installed CLI to prepare for its distribution among other package managers (brew, apt, choco, etc)