### PR TITLE
🐛 Include transforms in distributed package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "files": [
     "bin",
     "dist",
+    "transforms",
     "oclif.manifest.json"
   ],
   "engines": {


### PR DESCRIPTION
## What is this?

The transforms are located in their own dedicated top-level directory but that directory is not distributed with the package. This PR fixes that by adding the directory to the package.json files array