### PR TITLE
🐛 Handle transforming unexpected trees

### DIFF
--- a/test/transforms/import-default.test.js
+++ b/test/transforms/import-default.test.js
@@ -37,4 +37,18 @@ describe('Transforms - import-default.js', () => {
     expect(() => applyTransform(transform, {}))
       .toThrow('--percy-sdk is required');
   });
+
+  it('does not error when encountering unexpected trees', () => {
+    expect(applyTransform(transform, {
+      'percy-sdk': '@percy/sdk'
+    }, dedent`
+      let { percySnapshot } = require('@percy/sdk');
+      let foo = foobar(); // callee with no args
+      let bar; // declaration with no init
+    `)).toEqual(dedent`
+      let percySnapshot = require('@percy/sdk');
+      let foo = foobar(); // callee with no args
+      let bar; // declaration with no init
+    `);
+  });
 });

--- a/transforms/import-default.js
+++ b/transforms/import-default.js
@@ -29,13 +29,13 @@ export default function({ source }, { j }, options) {
   // + const <local> = require(<sdk>)
   root
     .find(j.VariableDeclarator, node => (
-      (node.init.type === 'CallExpression' &&
+      (node.init?.type === 'CallExpression' &&
        node.init.callee.name === 'require' &&
-       node.init.arguments[0].value === installed) ||
-      (node.init.type === 'MemberExpression' &&
+       node.init.arguments[0]?.value === installed) ||
+      (node.init?.type === 'MemberExpression' &&
        node.init.object.type === 'CallExpression' &&
        node.init.object.callee.name === 'require' &&
-       node.init.object.arguments[0].value === installed)
+       node.init.object.arguments[0]?.value === installed)
     ))
     .forEach(({ value: node }) => {
       let local = node.id.properties?.[0].value.name ?? node.id.name;


### PR DESCRIPTION
## What is this?

A variable declarator tree doesn't always contain an initializer. Similarly, a call expression tree doesn't always contain arguments. The first scenario is now tested and handled, however the second scenario didn't seem to hold true. The call expression tree did have at least a single argument of undefined or null. Unsure if this is an intentional or unintentional AST result, so it was accounted for anyway.

The test file name was also fixed to match the transform name.