### PR TITLE
✨ Confirm again when skipping CLI installation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,15 +96,22 @@ class Migrate extends Command {
   async confirmCLI({ agent, cli }) {
     if (cli) return;
 
-    let { installCLI } = await inquirer.prompt([{
+    let { installCLI, skipCLI } = await inquirer.prompt([{
       type: 'confirm',
       name: 'installCLI',
-      message: 'Install @percy/cli' +
-        (agent ? ' (and remove @percy/agent)?' : '?'),
+      message: `Install @percy/cli ${agent
+        ? '(and remove @percy/agent)?'
+        : '(required to run percy)?'}`,
       default: true
+    }, {
+      type: 'confirm',
+      name: 'skipCLI',
+      when: ({ installCLI }) => !installCLI,
+      message: 'Are you sure you want to skip installing @percy/cli?',
+      default: false
     }]);
 
-    if (installCLI) {
+    if (installCLI || !skipCLI) {
       if (agent) await npm.uninstall('@percy/agent');
       await npm.install('@percy/cli');
     }

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -18,6 +18,7 @@ describe('Config migration', () => {
     mockPackageJSON({});
 
     prompts = mockPrompts({
+      skipCLI: true,
       doConfig: true
     });
 
@@ -38,7 +39,7 @@ describe('Config migration', () => {
   it('confirms config migration', async () => {
     await Migrate('--only-cli');
 
-    expect(prompts[1]).toEqual({
+    expect(prompts[2]).toEqual({
       type: 'confirm',
       name: 'doConfig',
       message: 'Migrate Percy config file?',
@@ -69,7 +70,7 @@ describe('Config migration', () => {
     mockRequire('fs', { existsSync: () => false });
     await Migrate('--only-cli');
 
-    expect(prompts[1]).toEqual({
+    expect(prompts[2]).toEqual({
       type: 'confirm',
       name: 'doConfig',
       message: 'Migrate Percy config file?',
@@ -90,7 +91,7 @@ describe('Config migration', () => {
     mockConfigSearch(() => ({}));
     await Migrate('--only-cli');
 
-    expect(prompts[1]).toBeUndefined();
+    expect(prompts[2]).toBeUndefined();
     expect(migrated).toBe(false);
 
     expect(logger.stderr).toEqual([]);


### PR DESCRIPTION
## What is this?

We really want to encourage installing the CLI. The initial installation prompt was adjusted to briefly explain why the CLI should be installed. Upon declining, another prompt asks again but requires the opposite response to avoid accidentally skipping the CLI install because of an accidental keypress.

Closes #29 