### PR TITLE
✨  Add migration for `@percy/seleniumjs`

### DIFF
--- a/src/migrations/base.js
+++ b/src/migrations/base.js
@@ -32,9 +32,9 @@ class SDKMigration {
     return this.constructor.name;
   }
 
-  // get aliases() {
-  //   return this.constructor.aliases;
-  // }
+  get aliases() {
+    return this.constructor.aliases;
+  }
 
   get aliased() {
     return this.constructor.aliased;

--- a/src/migrations/index.js
+++ b/src/migrations/index.js
@@ -5,6 +5,7 @@ module.exports = [
   require('./nightwatch'),
   require('./protractor'),
   require('./webdriverio'),
+  require('./selenium-javascript'),
   // non-js
   require('./capybara'),
   require('./selenium-java'),

--- a/src/migrations/selenium-javascript.js
+++ b/src/migrations/selenium-javascript.js
@@ -1,0 +1,32 @@
+import path from 'path';
+import { run, npm } from '../utils';
+import SDKMigration from './base';
+
+class SeleniumJavaScriptMigration extends SDKMigration {
+  static name = '@percy/selenium-webdriver';
+  static aliases = ['@percy/seleniumjs'];
+  static version = '^1.0.0';
+
+  async upgrade() {
+    if (this.installed && this.aliases.includes(this.installed.name)) {
+      await npm.uninstall(this.installed.name);
+    }
+
+    await npm.install(`${this.name}@${this.version}`);
+  }
+
+  transforms = [{
+    message: 'SDK exports have changed, update imports?',
+    default: '{test,tests}/**/*{-test,.test}.{js,ts}',
+    async transform(paths) {
+      await run(require.resolve('jscodeshift/bin/jscodeshift'), [
+        `--transform=${path.resolve(__dirname, '../../transforms/import-default.js')}`,
+        this.installed && `--percy-installed=${this.installed.name}`,
+        `--percy-sdk=${this.name}`,
+        ...paths
+      ]);
+    }
+  }];
+}
+
+module.exports = SeleniumJavaScriptMigration;

--- a/test/migrations/selenium-javascript.js
+++ b/test/migrations/selenium-javascript.js
@@ -1,0 +1,119 @@
+import expect from 'expect';
+import globby from 'globby';
+import { Migrate, logger, setupMigrationTest } from '../helpers';
+
+describe('Migrations - @percy/selenium-webdriver', () => {
+  let jscodeshiftbin = require.resolve('jscodeshift/bin/jscodeshift');
+  let packageJSON, prompts, run;
+
+  beforeEach(() => {
+    ({ packageJSON, prompts, run } = setupMigrationTest('selenium-javascript', {
+      mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) }
+    }));
+  });
+
+  it('upgrades the sdk', async () => {
+    await Migrate('@percy/selenium-webdriver', '--skip-cli');
+
+    expect(prompts[1]).toEqual({
+      type: 'confirm',
+      name: 'upgradeSDK',
+      message: 'Upgrade SDK to @percy/selenium-webdriver@^1.0.0?',
+      default: true
+    });
+
+    expect(run.npm.calls[0].args).toEqual(['install', '--save-dev', '@percy/selenium-webdriver@^1.0.0']);
+
+    expect(logger.stderr).toEqual([]);
+    expect(logger.stdout).toEqual(['[percy] Migration complete!\n']);
+  });
+
+  it('transforms sdk imports', async () => {
+    await Migrate('@percy/selenium-webdriver', '--skip-cli');
+
+    expect(prompts[2]).toEqual({
+      type: 'confirm',
+      name: 'doTransform',
+      message: 'SDK exports have changed, update imports?',
+      default: true
+    });
+
+    expect(run[jscodeshiftbin].calls[0].args).toEqual([
+      `--transform=${require.resolve('../../transforms/import-default')}`,
+      '--percy-installed=@percy/selenium-webdriver',
+      '--percy-sdk=@percy/selenium-webdriver',
+      ...(await globby('test/**/*.test.js').then((f) => f.sort()))
+    ]);
+
+    expect(logger.stderr).toEqual([]);
+    expect(logger.stdout).toEqual(['[percy] Migration complete!\n']);
+  });
+
+  it('asks to transform sdk imports even when not installed', async () => {
+    delete packageJSON.devDependencies;
+
+    await Migrate('@percy/selenium-webdriver', '--skip-cli');
+
+    expect(prompts[2]).toEqual({
+      type: 'confirm',
+      name: 'doTransform',
+      message: 'SDK exports have changed, update imports?',
+      default: true
+    });
+
+    expect(run[jscodeshiftbin].calls[0].args).toEqual([
+      `--transform=${require.resolve('../../transforms/import-default')}`,
+      '--percy-sdk=@percy/selenium-webdriver',
+      ...(await globby('test/**/*.test.js').then((f) => f.sort()))
+    ]);
+
+    expect(logger.stderr).toEqual(['[percy] The specified SDK was not found in your dependencies\n']);
+    expect(logger.stdout).toEqual(['[percy] Migration complete!\n']);
+  });
+
+  describe('migrating from @percy/seleniumjs', () => {
+    beforeEach(() => {
+      // mock out having the old SDK installed
+      delete packageJSON.devDependencies['@percy/selenium-webdriver'];
+      packageJSON.devDependencies['@percy/seleniumjs'] = '^0.2.0';
+    });
+
+    it('uninstalls the old SDK', async () => {
+      await Migrate('@percy/selenium-webdriver', '--skip-cli');
+
+      expect(prompts[1]).toEqual({
+        type: 'confirm',
+        name: 'upgradeSDK',
+        message: 'Upgrade SDK to @percy/selenium-webdriver@^1.0.0?',
+        default: true
+      });
+
+      expect(run.npm.calls[0].args).toEqual(['uninstall', '@percy/seleniumjs']);
+      expect(run.npm.calls[1].args).toEqual(['install', '--save-dev', '@percy/selenium-webdriver@^1.0.0']);
+
+      expect(logger.stderr).toEqual([]);
+      expect(logger.stdout).toEqual(['[percy] Migration complete!\n']);
+    });
+
+    it('transforms sdk imports', async () => {
+      await Migrate('@percy/selenium-webdriver', '--skip-cli');
+
+      expect(prompts[2]).toEqual({
+        type: 'confirm',
+        name: 'doTransform',
+        message: 'SDK exports have changed, update imports?',
+        default: true
+      });
+
+      expect(run[jscodeshiftbin].calls[0].args).toEqual([
+        `--transform=${require.resolve('../../transforms/import-default')}`,
+        '--percy-installed=@percy/seleniumjs',
+        '--percy-sdk=@percy/selenium-webdriver',
+        ...(await globby('test/**/*.test.js').then((f) => f.sort()))
+      ]);
+
+      expect(logger.stderr).toEqual([]);
+      expect(logger.stdout).toEqual(['[percy] Migration complete!\n']);
+    });
+  });
+});


### PR DESCRIPTION
## What is this?

This adds the SDK migration to get users to move from `@percy/seleniumjs` to `@percy/selenium-webdriver`. 