### PR TITLE
🐛  Fix transforms default glob path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -239,6 +239,11 @@ class Migrate extends Command {
         filter: glob => globby(glob)
       }]);
 
+      if (!filePaths?.length) {
+        this.log.error('Could not find any files matching the pattern');
+        continue;
+      }
+
       await t.transform.call(sdk, filePaths);
     }
   }

--- a/src/migrations/nightmare.js
+++ b/src/migrations/nightmare.js
@@ -12,7 +12,7 @@ class NightmareMigration extends SDKMigration {
 
   transforms = [{
     message: 'SDK exports have changed, update imports?',
-    default: '{test,tests}/**/*{-test,.test}.{js,ts}',
+    default: '{test,spec}?(s)/**/*.js',
     async transform(paths) {
       await run(require.resolve('jscodeshift/bin/jscodeshift'), [
         `--transform=${path.resolve(__dirname, '../../transforms/import-default.js')}`,

--- a/src/migrations/protractor.js
+++ b/src/migrations/protractor.js
@@ -12,7 +12,7 @@ class ProtractorMigration extends SDKMigration {
 
   transforms = [{
     message: 'SDK exports have changed, update imports?',
-    default: '{test,tests}/**/*{-test,.test}.{js,ts}',
+    default: '{test,spec}?(s)/**/*.js',
     async transform(paths) {
       await run(require.resolve('jscodeshift/bin/jscodeshift'), [
         `--transform=${path.resolve(__dirname, '../../transforms/import-default.js')}`,

--- a/src/migrations/puppeteer.js
+++ b/src/migrations/puppeteer.js
@@ -12,7 +12,7 @@ class PuppeteerMigration extends SDKMigration {
 
   transforms = [{
     message: 'SDK exports have changed, update imports?',
-    default: '{test,tests}/**/*{-test,.test}.{js,ts}',
+    default: '{test,spec}?(s)/**/*.js',
     async transform(paths) {
       await run(require.resolve('jscodeshift/bin/jscodeshift'), [
         `--transform=${path.resolve(__dirname, '../../transforms/import-default.js')}`,

--- a/src/migrations/selenium-javascript.js
+++ b/src/migrations/selenium-javascript.js
@@ -17,7 +17,7 @@ class SeleniumJavaScriptMigration extends SDKMigration {
 
   transforms = [{
     message: 'The SDK package name has changed, update imports?',
-    default: '{test,tests}/**/*{-test,.test}.{js,ts}',
+    default: '{test,spec}?(s)/**/*.js',
     async transform(paths) {
       await run(require.resolve('jscodeshift/bin/jscodeshift'), [
         `--transform=${path.resolve(__dirname, '../../transforms/import-default.js')}`,

--- a/src/migrations/webdriverio.js
+++ b/src/migrations/webdriverio.js
@@ -12,7 +12,7 @@ class WebDriverIOMigration extends SDKMigration {
 
   transforms = [{
     message: 'SDK exports have changed, update imports?',
-    default: '{test,tests}/**/*{-test,.test}.{js,ts}',
+    default: '{test,spec}?(s)/**/*.js',
     async transform(paths) {
       await run(require.resolve('jscodeshift/bin/jscodeshift'), [
         `--transform=${path.resolve(__dirname, '../../transforms/import-default.js')}`,

--- a/test/migrations/nightmare.test.js
+++ b/test/migrations/nightmare.test.js
@@ -49,7 +49,7 @@ describe('Migrations - @percy/nightmare', () => {
       `--transform=${require.resolve('../../transforms/import-default')}`,
       '--percy-installed=@percy/nightmare',
       '--percy-sdk=@percy/nightmare',
-      ...(await globby('test/**/*.test.js').then(f => f.sort()))
+      ...(await globby('test/**/*.js').then(f => f.sort()))
     ]);
 
     expect(logger.stderr).toEqual([]);
@@ -73,7 +73,7 @@ describe('Migrations - @percy/nightmare', () => {
     expect(run[jscodeshiftbin].calls[0].args).toEqual([
       `--transform=${require.resolve('../../transforms/import-default')}`,
       '--percy-sdk=@percy/nightmare',
-      ...(await globby('test/**/*.test.js').then(f => f.sort()))
+      ...(await globby('test/**/*.js').then(f => f.sort()))
     ]);
 
     expect(logger.stderr).toEqual([

--- a/test/migrations/protractor.test.js
+++ b/test/migrations/protractor.test.js
@@ -49,7 +49,7 @@ describe('Migrations - @percy/protractor', () => {
       `--transform=${require.resolve('../../transforms/import-default')}`,
       '--percy-installed=@percy/protractor',
       '--percy-sdk=@percy/protractor',
-      ...(await globby('test/**/*.test.js').then(f => f.sort()))
+      ...(await globby('test/**/*.js').then(f => f.sort()))
     ]);
 
     expect(logger.stderr).toEqual([]);
@@ -73,7 +73,7 @@ describe('Migrations - @percy/protractor', () => {
     expect(run[jscodeshiftbin].calls[0].args).toEqual([
       `--transform=${require.resolve('../../transforms/import-default')}`,
       '--percy-sdk=@percy/protractor',
-      ...(await globby('test/**/*.test.js').then(f => f.sort()))
+      ...(await globby('test/**/*.js').then(f => f.sort()))
     ]);
 
     expect(logger.stderr).toEqual([

--- a/test/migrations/puppeteer.test.js
+++ b/test/migrations/puppeteer.test.js
@@ -49,7 +49,7 @@ describe('Migrations - @percy/puppeteer', () => {
       `--transform=${require.resolve('../../transforms/import-default')}`,
       '--percy-installed=@percy/puppeteer',
       '--percy-sdk=@percy/puppeteer',
-      ...(await globby('test/**/*.test.js').then(f => f.sort()))
+      ...(await globby('test/**/*.js').then(f => f.sort()))
     ]);
 
     expect(logger.stderr).toEqual([]);
@@ -73,7 +73,7 @@ describe('Migrations - @percy/puppeteer', () => {
     expect(run[jscodeshiftbin].calls[0].args).toEqual([
       `--transform=${require.resolve('../../transforms/import-default')}`,
       '--percy-sdk=@percy/puppeteer',
-      ...(await globby('test/**/*.test.js').then(f => f.sort()))
+      ...(await globby('test/**/*.js').then(f => f.sort()))
     ]);
 
     expect(logger.stderr).toEqual([

--- a/test/migrations/selenium-javascript.js
+++ b/test/migrations/selenium-javascript.js
@@ -42,7 +42,7 @@ describe('Migrations - @percy/selenium-webdriver', () => {
       `--transform=${require.resolve('../../transforms/import-default')}`,
       '--percy-installed=@percy/selenium-webdriver',
       '--percy-sdk=@percy/selenium-webdriver',
-      ...(await globby('test/**/*.test.js').then((f) => f.sort()))
+      ...(await globby('test/**/*.js').then((f) => f.sort()))
     ]);
 
     expect(logger.stderr).toEqual([]);
@@ -64,7 +64,7 @@ describe('Migrations - @percy/selenium-webdriver', () => {
     expect(run[jscodeshiftbin].calls[0].args).toEqual([
       `--transform=${require.resolve('../../transforms/import-default')}`,
       '--percy-sdk=@percy/selenium-webdriver',
-      ...(await globby('test/**/*.test.js').then((f) => f.sort()))
+      ...(await globby('test/**/*.js').then((f) => f.sort()))
     ]);
 
     expect(logger.stderr).toEqual(['[percy] The specified SDK was not found in your dependencies\n']);
@@ -109,7 +109,7 @@ describe('Migrations - @percy/selenium-webdriver', () => {
         `--transform=${require.resolve('../../transforms/import-default')}`,
         '--percy-installed=@percy/seleniumjs',
         '--percy-sdk=@percy/selenium-webdriver',
-        ...(await globby('test/**/*.test.js').then((f) => f.sort()))
+        ...(await globby('test/**/*.js').then((f) => f.sort()))
       ]);
 
       expect(logger.stderr).toEqual([]);

--- a/test/migrations/webdriverio.test.js
+++ b/test/migrations/webdriverio.test.js
@@ -49,7 +49,7 @@ describe('Migrations - @percy/webdriverio', () => {
       `--transform=${require.resolve('../../transforms/import-default')}`,
       '--percy-installed=@percy/webdriverio',
       '--percy-sdk=@percy/webdriverio',
-      ...(await globby('test/**/*.test.js').then(f => f.sort()))
+      ...(await globby('test/**/*.js').then(f => f.sort()))
     ]);
 
     expect(logger.stderr).toEqual([]);
@@ -73,7 +73,7 @@ describe('Migrations - @percy/webdriverio', () => {
     expect(run[jscodeshiftbin].calls[0].args).toEqual([
       `--transform=${require.resolve('../../transforms/import-default')}`,
       '--percy-sdk=@percy/webdriverio',
-      ...(await globby('test/**/*.test.js').then(f => f.sort()))
+      ...(await globby('test/**/*.js').then(f => f.sort()))
     ]);
 
     expect(logger.stderr).toEqual([

--- a/test/transforms.test.js
+++ b/test/transforms.test.js
@@ -12,22 +12,6 @@ describe('SDK transforms', () => {
   let transformed, prompts;
 
   beforeEach(() => {
-    transformed = [];
-
-    mockMigrations([{
-      name: '@percy/sdk-test',
-      version: '^2.0.0',
-      transforms: [{
-        message: 'Run this transform?',
-        default: 'test/**/*.test.js',
-        transform: paths => (transformed = paths)
-      }, {
-        message: 'How about this one?',
-        default: 'foo/**/*.bar.js',
-        transform: () => {}
-      }]
-    }]);
-
     mockPackageJSON({
       devDependencies: {
         '@percy/sdk-test': '^1.0.0'
@@ -40,63 +24,118 @@ describe('SDK transforms', () => {
     });
   });
 
-  it('confirms any SDK transforms', async () => {
-    await Migrate('@percy/sdk-test', '--skip-cli');
+  describe('with matching paths', () => {
+    beforeEach(() => {
+      transformed = [];
 
-    expect(prompts[2]).toEqual({
-      type: 'confirm',
-      name: 'doTransform',
-      message: 'Run this transform?',
-      default: true
+      mockMigrations([{
+        name: '@percy/sdk-test',
+        version: '^2.0.0',
+        transforms: [{
+          message: 'Run this transform?',
+          default: 'test/**/*.js',
+          transform: paths => (transformed = paths)
+        }, {
+          message: 'How about this one?',
+          default: 'test/**/*.js',
+          transform: () => {}
+        }]
+      }]);
     });
 
-    expect(prompts[3]).toEqual({
-      type: 'confirm',
-      name: 'doTransform',
-      message: 'How about this one?',
-      default: true
+    it('confirms any SDK transforms', async () => {
+      await Migrate('@percy/sdk-test', '--skip-cli');
+
+      expect(prompts[2]).toEqual({
+        type: 'confirm',
+        name: 'doTransform',
+        message: 'Run this transform?',
+        default: true
+      });
+
+      expect(prompts[3]).toEqual({
+        type: 'confirm',
+        name: 'doTransform',
+        message: 'How about this one?',
+        default: true
+      });
+
+      expect(logger.stderr).toEqual([]);
+      expect(logger.stdout).toEqual([
+        '[percy] Migration complete!\n'
+      ]);
     });
 
-    expect(logger.stderr).toEqual([]);
-    expect(logger.stdout).toEqual([
-      '[percy] Migration complete!\n'
-    ]);
+    it('asks for filepaths to transform when confirmed', async () => {
+      prompts = mockPrompts({
+        isSDK: true,
+        doTransform: true,
+        filePaths: q => q.filter(q.default)
+          .then(f => f.sort())
+      });
+
+      await Migrate('@percy/sdk-test', '--skip-cli');
+
+      expect(prompts[3]).toEqual({
+        type: 'input',
+        name: 'filePaths',
+        message: 'Which files?',
+        default: 'test/**/*.js',
+        filter: expect.any(Function)
+      });
+
+      expect(prompts[5]).toEqual({
+        type: 'input',
+        name: 'filePaths',
+        message: 'Which files?',
+        default: 'test/**/*.js',
+        filter: expect.any(Function)
+      });
+
+      expect(transformed).toEqual(
+        await globby('test/**/*.js')
+          .then(f => f.sort())
+      );
+
+      expect(logger.stderr).toEqual([]);
+      expect(logger.stdout).toEqual([
+        '[percy] Migration complete!\n'
+      ]);
+    });
   });
 
-  it('asks for filepaths to transform when confirmed', async () => {
-    prompts = mockPrompts({
-      isSDK: true,
-      doTransform: true,
-      filePaths: q => q.filter(q.default)
-        .then(f => f.sort())
+  describe('without matching paths', () => {
+    beforeEach(() => {
+      transformed = false;
+
+      mockMigrations([{
+        name: '@percy/sdk-test',
+        version: '^2.0.0',
+        transforms: [{
+          message: 'Never match',
+          default: 'no/files/should/match.ha',
+          transform: () => (transformed = true)
+        }]
+      }]);
     });
 
-    await Migrate('@percy/sdk-test', '--skip-cli');
+    it('logs an error when no matching paths found', async () => {
+      mockPrompts({
+        isSDK: true,
+        doTransform: true,
+        filePaths: q => q.filter(q.default)
+          .then(f => f.sort())
+      });
 
-    expect(prompts[3]).toEqual({
-      type: 'input',
-      name: 'filePaths',
-      message: 'Which files?',
-      default: 'test/**/*.test.js',
-      filter: expect.any(Function)
+      await Migrate('@percy/sdk-test', '--skip-cli');
+
+      expect(transformed).toBe(false);
+      expect(logger.stderr).toEqual([
+        '[percy] Could not find any files matching the pattern\n'
+      ]);
+      expect(logger.stdout).toEqual([
+        '[percy] Migration complete!\n'
+      ]);
     });
-
-    expect(prompts[5]).toEqual({
-      type: 'input',
-      name: 'filePaths',
-      message: 'Which files?',
-      default: 'foo/**/*.bar.js',
-      filter: expect.any(Function)
-    });
-
-    expect(transformed).toEqual(
-      await globby('test/**/*.test.js')
-        .then(f => f.sort())
-    );
-
-    expect(logger.stderr).toEqual([]);
-    expect(logger.stdout).toEqual([
-      '[percy] Migration complete!\n'
-    ]);
   });
 });


### PR DESCRIPTION
## Purpose

While testing migrate out on some OSS projects I noticed the default globs weren't working (also noticed this on the example apps too.. oops). 

Once we worked past that, it turns out `ts` files aren't supported out of the box. We assumed jscodeshift would be able to handle TS files automatically, but it turns out we're going to have to toggle the parser based on the file extension.

## Approach

At first the default globs were meant to try and match test framework structures. But this doesn't account for Percy being used in helper files (or other paths of that nature). The new default glob looks to match any JS file inside of a `test` or `spec` folder (`{test,spec}?(s)/**/*.js`).

Next up, this PR removes the `ts` from the glob pattern. _Actual_ support TS will arrive in a follow up PR (so we can toggle the parser in jscodeshift). 

Lastly, as a nice catch, we now log a Percy error & break if the filepaths passed don't match any files. This prevents jscodeshift from running and then throwing a big (and sort of) confusing error stack trace. That error is thrown because we're invoking jscodeshift with no matching folders (so it prints a help log)