### PR TITLE
✨ Transform TypeScript files

### DIFF
--- a/src/migrations/nightmare.js
+++ b/src/migrations/nightmare.js
@@ -12,11 +12,12 @@ class NightmareMigration extends SDKMigration {
 
   transforms = [{
     message: 'SDK exports have changed, update imports?',
-    default: '{test,spec}?(s)/**/*.js',
+    default: '{test,spec}?(s)/**/*.{js,ts}',
     async transform(paths) {
       await run(require.resolve('jscodeshift/bin/jscodeshift'), [
         `--transform=${path.resolve(__dirname, '../../transforms/import-default.js')}`,
         this.installed && `--percy-installed=${this.installed.name}`,
+        paths.some((p) => p.endsWith('.ts')) && '--parser=ts',
         `--percy-sdk=${this.name}`,
         ...paths
       ]);

--- a/src/migrations/protractor.js
+++ b/src/migrations/protractor.js
@@ -12,11 +12,12 @@ class ProtractorMigration extends SDKMigration {
 
   transforms = [{
     message: 'SDK exports have changed, update imports?',
-    default: '{test,spec}?(s)/**/*.js',
+    default: '{test,spec}?(s)/**/*.{js,ts}',
     async transform(paths) {
       await run(require.resolve('jscodeshift/bin/jscodeshift'), [
         `--transform=${path.resolve(__dirname, '../../transforms/import-default.js')}`,
         this.installed && `--percy-installed=${this.installed.name}`,
+        paths.some((p) => p.endsWith('.ts')) && '--parser=ts',
         `--percy-sdk=${this.name}`,
         ...paths
       ]);

--- a/src/migrations/puppeteer.js
+++ b/src/migrations/puppeteer.js
@@ -12,11 +12,12 @@ class PuppeteerMigration extends SDKMigration {
 
   transforms = [{
     message: 'SDK exports have changed, update imports?',
-    default: '{test,spec}?(s)/**/*.js',
+    default: '{test,spec}?(s)/**/*.{js,ts}',
     async transform(paths) {
       await run(require.resolve('jscodeshift/bin/jscodeshift'), [
         `--transform=${path.resolve(__dirname, '../../transforms/import-default.js')}`,
         this.installed && `--percy-installed=${this.installed.name}`,
+        paths.some((p) => p.endsWith('.ts')) && '--parser=ts',
         `--percy-sdk=${this.name}`,
         ...paths
       ]);

--- a/src/migrations/selenium-javascript.js
+++ b/src/migrations/selenium-javascript.js
@@ -17,11 +17,12 @@ class SeleniumJavaScriptMigration extends SDKMigration {
 
   transforms = [{
     message: 'The SDK package name has changed, update imports?',
-    default: '{test,spec}?(s)/**/*.js',
+    default: '{test,spec}?(s)/**/*.{js,ts}',
     async transform(paths) {
       await run(require.resolve('jscodeshift/bin/jscodeshift'), [
         `--transform=${path.resolve(__dirname, '../../transforms/import-default.js')}`,
         this.installed && `--percy-installed=${this.installed.name}`,
+        paths.some((p) => p.endsWith('.ts')) && '--parser=ts',
         `--percy-sdk=${this.name}`,
         ...paths
       ]);

--- a/src/migrations/webdriverio.js
+++ b/src/migrations/webdriverio.js
@@ -12,11 +12,12 @@ class WebDriverIOMigration extends SDKMigration {
 
   transforms = [{
     message: 'SDK exports have changed, update imports?',
-    default: '{test,spec}?(s)/**/*.js',
+    default: '{test,spec}?(s)/**/*.{js,ts}',
     async transform(paths) {
       await run(require.resolve('jscodeshift/bin/jscodeshift'), [
         `--transform=${path.resolve(__dirname, '../../transforms/import-default.js')}`,
         this.installed && `--percy-installed=${this.installed.name}`,
+        paths.some((p) => p.endsWith('.ts')) && '--parser=ts',
         `--percy-sdk=${this.name}`,
         ...paths
       ]);

--- a/test/helpers/apply-transform.js
+++ b/test/helpers/apply-transform.js
@@ -28,8 +28,8 @@ export function dedent(raw, ...values) {
 }
 
 // Call the transform function with the appropriate arguments
-export default function applyTransform(module, options = {}, source) {
+export default function applyTransform(module, options = {}, source, path = 'test.js') {
   let transform = module.default ?? module;
   let api = { j: jscodeshift, jscodeshift };
-  return transform({ source }, api, options);
+  return transform({ path, source }, api, options);
 }

--- a/test/helpers/setup-migration.js
+++ b/test/helpers/setup-migration.js
@@ -15,8 +15,7 @@ export default function setupMigrationTest(filename, mocks) {
     isSDK: true,
     upgradeSDK: true,
     doTransform: true,
-    filePaths: q => q.filter(q.default)
-      .then(f => f.sort()),
+    filePaths: mocks.filePaths,
     ...mocks.mockPrompts
   });
 

--- a/test/helpers/setup-migration.js
+++ b/test/helpers/setup-migration.js
@@ -15,7 +15,7 @@ export default function setupMigrationTest(filename, mocks) {
     isSDK: true,
     upgradeSDK: true,
     doTransform: true,
-    filePaths: mocks.filePaths,
+    filePaths: ['test/foo.js', 'test/bar.js', 'test/bazz.js'],
     ...mocks.mockPrompts
   });
 

--- a/test/migrations/nightmare.test.js
+++ b/test/migrations/nightmare.test.js
@@ -1,5 +1,4 @@
 import expect from 'expect';
-import globby from 'globby';
 import {
   Migrate,
   logger,
@@ -12,7 +11,8 @@ describe('Migrations - @percy/nightmare', () => {
 
   beforeEach(() => {
     ({ packageJSON, prompts, run } = setupMigrationTest('nightmare', {
-      mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) }
+      mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) },
+      filePaths: ['test/foo.js', 'test/bar.js', 'test/bazz.js']
     }));
   });
 
@@ -49,7 +49,9 @@ describe('Migrations - @percy/nightmare', () => {
       `--transform=${require.resolve('../../transforms/import-default')}`,
       '--percy-installed=@percy/nightmare',
       '--percy-sdk=@percy/nightmare',
-      ...(await globby('test/**/*.js').then(f => f.sort()))
+      'test/foo.js',
+      'test/bar.js',
+      'test/bazz.js'
     ]);
 
     expect(logger.stderr).toEqual([]);
@@ -73,7 +75,9 @@ describe('Migrations - @percy/nightmare', () => {
     expect(run[jscodeshiftbin].calls[0].args).toEqual([
       `--transform=${require.resolve('../../transforms/import-default')}`,
       '--percy-sdk=@percy/nightmare',
-      ...(await globby('test/**/*.js').then(f => f.sort()))
+      'test/foo.js',
+      'test/bar.js',
+      'test/bazz.js'
     ]);
 
     expect(logger.stderr).toEqual([

--- a/test/migrations/nightmare.test.js
+++ b/test/migrations/nightmare.test.js
@@ -87,4 +87,37 @@ describe('Migrations - @percy/nightmare', () => {
       '[percy] Migration complete!\n'
     ]);
   });
+
+  describe('with TypeScript files', () => {
+    beforeEach(() => {
+      ({ packageJSON, prompts, run } = setupMigrationTest('nightmare', {
+        mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) },
+        filePaths: ['test/bar.ts']
+      }));
+    });
+
+    it('transforms sdk imports for TypeScript', async () => {
+      await Migrate('@percy/nightmare', '--skip-cli');
+
+      expect(prompts[2]).toEqual({
+        type: 'confirm',
+        name: 'doTransform',
+        message: 'SDK exports have changed, update imports?',
+        default: true
+      });
+
+      expect(run[jscodeshiftbin].calls[0].args).toEqual([
+        `--transform=${require.resolve('../../transforms/import-default')}`,
+        '--percy-installed=@percy/nightmare',
+        '--parser=ts',
+        '--percy-sdk=@percy/nightmare',
+        'test/bar.ts'
+      ]);
+
+      expect(logger.stderr).toEqual([]);
+      expect(logger.stdout).toEqual([
+        '[percy] Migration complete!\n'
+      ]);
+    });
+  });
 });

--- a/test/migrations/nightmare.test.js
+++ b/test/migrations/nightmare.test.js
@@ -11,8 +11,7 @@ describe('Migrations - @percy/nightmare', () => {
 
   beforeEach(() => {
     ({ packageJSON, prompts, run } = setupMigrationTest('nightmare', {
-      mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) },
-      filePaths: ['test/foo.js', 'test/bar.js', 'test/bazz.js']
+      mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) }
     }));
   });
 
@@ -92,7 +91,7 @@ describe('Migrations - @percy/nightmare', () => {
     beforeEach(() => {
       ({ packageJSON, prompts, run } = setupMigrationTest('nightmare', {
         mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) },
-        filePaths: ['test/bar.ts']
+        mockPrompts: { filePaths: ['test/bar.ts'] }
       }));
     });
 

--- a/test/migrations/protractor.test.js
+++ b/test/migrations/protractor.test.js
@@ -87,4 +87,37 @@ describe('Migrations - @percy/protractor', () => {
       '[percy] Migration complete!\n'
     ]);
   });
+
+  describe('with TypeScript files', () => {
+    beforeEach(() => {
+      ({ packageJSON, prompts, run } = setupMigrationTest('protractor', {
+        mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) },
+        filePaths: ['test/bar.ts']
+      }));
+    });
+
+    it('transforms sdk imports for TypeScript', async () => {
+      await Migrate('@percy/protractor', '--skip-cli');
+
+      expect(prompts[2]).toEqual({
+        type: 'confirm',
+        name: 'doTransform',
+        message: 'SDK exports have changed, update imports?',
+        default: true
+      });
+
+      expect(run[jscodeshiftbin].calls[0].args).toEqual([
+        `--transform=${require.resolve('../../transforms/import-default')}`,
+        '--percy-installed=@percy/protractor',
+        '--parser=ts',
+        '--percy-sdk=@percy/protractor',
+        'test/bar.ts'
+      ]);
+
+      expect(logger.stderr).toEqual([]);
+      expect(logger.stdout).toEqual([
+        '[percy] Migration complete!\n'
+      ]);
+    });
+  });
 });

--- a/test/migrations/protractor.test.js
+++ b/test/migrations/protractor.test.js
@@ -1,5 +1,4 @@
 import expect from 'expect';
-import globby from 'globby';
 import {
   Migrate,
   logger,
@@ -12,7 +11,8 @@ describe('Migrations - @percy/protractor', () => {
 
   beforeEach(() => {
     ({ packageJSON, prompts, run } = setupMigrationTest('protractor', {
-      mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) }
+      mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) },
+      filePaths: ['test/foo.js', 'test/bar.js', 'test/bazz.js']
     }));
   });
 
@@ -49,7 +49,9 @@ describe('Migrations - @percy/protractor', () => {
       `--transform=${require.resolve('../../transforms/import-default')}`,
       '--percy-installed=@percy/protractor',
       '--percy-sdk=@percy/protractor',
-      ...(await globby('test/**/*.js').then(f => f.sort()))
+      'test/foo.js',
+      'test/bar.js',
+      'test/bazz.js'
     ]);
 
     expect(logger.stderr).toEqual([]);
@@ -73,7 +75,9 @@ describe('Migrations - @percy/protractor', () => {
     expect(run[jscodeshiftbin].calls[0].args).toEqual([
       `--transform=${require.resolve('../../transforms/import-default')}`,
       '--percy-sdk=@percy/protractor',
-      ...(await globby('test/**/*.js').then(f => f.sort()))
+      'test/foo.js',
+      'test/bar.js',
+      'test/bazz.js'
     ]);
 
     expect(logger.stderr).toEqual([

--- a/test/migrations/protractor.test.js
+++ b/test/migrations/protractor.test.js
@@ -11,8 +11,7 @@ describe('Migrations - @percy/protractor', () => {
 
   beforeEach(() => {
     ({ packageJSON, prompts, run } = setupMigrationTest('protractor', {
-      mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) },
-      filePaths: ['test/foo.js', 'test/bar.js', 'test/bazz.js']
+      mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) }
     }));
   });
 
@@ -92,7 +91,7 @@ describe('Migrations - @percy/protractor', () => {
     beforeEach(() => {
       ({ packageJSON, prompts, run } = setupMigrationTest('protractor', {
         mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) },
-        filePaths: ['test/bar.ts']
+        mockPrompts: { filePaths: ['test/bar.ts'] }
       }));
     });
 

--- a/test/migrations/puppeteer.test.js
+++ b/test/migrations/puppeteer.test.js
@@ -1,5 +1,4 @@
 import expect from 'expect';
-import globby from 'globby';
 import {
   Migrate,
   logger,
@@ -12,7 +11,8 @@ describe('Migrations - @percy/puppeteer', () => {
 
   beforeEach(() => {
     ({ packageJSON, prompts, run } = setupMigrationTest('puppeteer', {
-      mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) }
+      mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) },
+      filePaths: ['test/foo.js', 'test/bar.js', 'test/bazz.js']
     }));
   });
 
@@ -49,7 +49,9 @@ describe('Migrations - @percy/puppeteer', () => {
       `--transform=${require.resolve('../../transforms/import-default')}`,
       '--percy-installed=@percy/puppeteer',
       '--percy-sdk=@percy/puppeteer',
-      ...(await globby('test/**/*.js').then(f => f.sort()))
+      'test/foo.js',
+      'test/bar.js',
+      'test/bazz.js'
     ]);
 
     expect(logger.stderr).toEqual([]);
@@ -73,7 +75,9 @@ describe('Migrations - @percy/puppeteer', () => {
     expect(run[jscodeshiftbin].calls[0].args).toEqual([
       `--transform=${require.resolve('../../transforms/import-default')}`,
       '--percy-sdk=@percy/puppeteer',
-      ...(await globby('test/**/*.js').then(f => f.sort()))
+      'test/foo.js',
+      'test/bar.js',
+      'test/bazz.js'
     ]);
 
     expect(logger.stderr).toEqual([

--- a/test/migrations/puppeteer.test.js
+++ b/test/migrations/puppeteer.test.js
@@ -11,8 +11,7 @@ describe('Migrations - @percy/puppeteer', () => {
 
   beforeEach(() => {
     ({ packageJSON, prompts, run } = setupMigrationTest('puppeteer', {
-      mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) },
-      filePaths: ['test/foo.js', 'test/bar.js', 'test/bazz.js']
+      mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) }
     }));
   });
 
@@ -92,7 +91,7 @@ describe('Migrations - @percy/puppeteer', () => {
     beforeEach(() => {
       ({ packageJSON, prompts, run } = setupMigrationTest('puppeteer', {
         mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) },
-        filePaths: ['test/bar.ts']
+        mockPrompts: { filePaths: ['test/bar.ts'] }
       }));
     });
 

--- a/test/migrations/puppeteer.test.js
+++ b/test/migrations/puppeteer.test.js
@@ -87,4 +87,37 @@ describe('Migrations - @percy/puppeteer', () => {
       '[percy] Migration complete!\n'
     ]);
   });
+
+  describe('with TypeScript files', () => {
+    beforeEach(() => {
+      ({ packageJSON, prompts, run } = setupMigrationTest('puppeteer', {
+        mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) },
+        filePaths: ['test/bar.ts']
+      }));
+    });
+
+    it('transforms sdk imports for TypeScript', async () => {
+      await Migrate('@percy/puppeteer', '--skip-cli');
+
+      expect(prompts[2]).toEqual({
+        type: 'confirm',
+        name: 'doTransform',
+        message: 'SDK exports have changed, update imports?',
+        default: true
+      });
+
+      expect(run[jscodeshiftbin].calls[0].args).toEqual([
+        `--transform=${require.resolve('../../transforms/import-default')}`,
+        '--percy-installed=@percy/puppeteer',
+        '--parser=ts',
+        '--percy-sdk=@percy/puppeteer',
+        'test/bar.ts'
+      ]);
+
+      expect(logger.stderr).toEqual([]);
+      expect(logger.stdout).toEqual([
+        '[percy] Migration complete!\n'
+      ]);
+    });
+  });
 });

--- a/test/migrations/selenium-javascript.js
+++ b/test/migrations/selenium-javascript.js
@@ -7,8 +7,7 @@ describe('Migrations - @percy/selenium-webdriver', () => {
 
   beforeEach(() => {
     ({ packageJSON, prompts, run } = setupMigrationTest('selenium-javascript', {
-      mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) },
-      filePaths: ['test/foo.js', 'test/bar.js', 'test/bazz.js']
+      mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) }
     }));
   });
 
@@ -127,7 +126,7 @@ describe('Migrations - @percy/selenium-webdriver', () => {
     beforeEach(() => {
       ({ packageJSON, prompts, run } = setupMigrationTest('selenium-javascript', {
         mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) },
-        filePaths: ['test/bar.ts']
+        mockPrompts: { filePaths: ['test/bar.ts'] }
       }));
     });
 

--- a/test/migrations/selenium-javascript.js
+++ b/test/migrations/selenium-javascript.js
@@ -122,4 +122,37 @@ describe('Migrations - @percy/selenium-webdriver', () => {
       expect(logger.stdout).toEqual(['[percy] Migration complete!\n']);
     });
   });
+
+  describe('with TypeScript files', () => {
+    beforeEach(() => {
+      ({ packageJSON, prompts, run } = setupMigrationTest('selenium-javascript', {
+        mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) },
+        filePaths: ['test/bar.ts']
+      }));
+    });
+
+    it('transforms sdk imports for TypeScript', async () => {
+      await Migrate('@percy/selenium-webdriver', '--skip-cli');
+
+      expect(prompts[2]).toEqual({
+        type: 'confirm',
+        name: 'doTransform',
+        message: 'The SDK package name has changed, update imports?',
+        default: true
+      });
+
+      expect(run[jscodeshiftbin].calls[0].args).toEqual([
+        `--transform=${require.resolve('../../transforms/import-default')}`,
+        '--percy-installed=@percy/selenium-webdriver',
+        '--parser=ts',
+        '--percy-sdk=@percy/selenium-webdriver',
+        'test/bar.ts'
+      ]);
+
+      expect(logger.stderr).toEqual([]);
+      expect(logger.stdout).toEqual([
+        '[percy] Migration complete!\n'
+      ]);
+    });
+  });
 });

--- a/test/migrations/selenium-javascript.js
+++ b/test/migrations/selenium-javascript.js
@@ -1,5 +1,4 @@
 import expect from 'expect';
-import globby from 'globby';
 import { Migrate, logger, setupMigrationTest } from '../helpers';
 
 describe('Migrations - @percy/selenium-webdriver', () => {
@@ -8,7 +7,8 @@ describe('Migrations - @percy/selenium-webdriver', () => {
 
   beforeEach(() => {
     ({ packageJSON, prompts, run } = setupMigrationTest('selenium-javascript', {
-      mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) }
+      mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) },
+      filePaths: ['test/foo.js', 'test/bar.js', 'test/bazz.js']
     }));
   });
 
@@ -42,7 +42,9 @@ describe('Migrations - @percy/selenium-webdriver', () => {
       `--transform=${require.resolve('../../transforms/import-default')}`,
       '--percy-installed=@percy/selenium-webdriver',
       '--percy-sdk=@percy/selenium-webdriver',
-      ...(await globby('test/**/*.js').then((f) => f.sort()))
+      'test/foo.js',
+      'test/bar.js',
+      'test/bazz.js'
     ]);
 
     expect(logger.stderr).toEqual([]);
@@ -64,7 +66,9 @@ describe('Migrations - @percy/selenium-webdriver', () => {
     expect(run[jscodeshiftbin].calls[0].args).toEqual([
       `--transform=${require.resolve('../../transforms/import-default')}`,
       '--percy-sdk=@percy/selenium-webdriver',
-      ...(await globby('test/**/*.js').then((f) => f.sort()))
+      'test/foo.js',
+      'test/bar.js',
+      'test/bazz.js'
     ]);
 
     expect(logger.stderr).toEqual(['[percy] The specified SDK was not found in your dependencies\n']);
@@ -109,7 +113,9 @@ describe('Migrations - @percy/selenium-webdriver', () => {
         `--transform=${require.resolve('../../transforms/import-default')}`,
         '--percy-installed=@percy/seleniumjs',
         '--percy-sdk=@percy/selenium-webdriver',
-        ...(await globby('test/**/*.js').then((f) => f.sort()))
+        'test/foo.js',
+        'test/bar.js',
+        'test/bazz.js'
       ]);
 
       expect(logger.stderr).toEqual([]);

--- a/test/migrations/webdriverio.test.js
+++ b/test/migrations/webdriverio.test.js
@@ -87,4 +87,37 @@ describe('Migrations - @percy/webdriverio', () => {
       '[percy] Migration complete!\n'
     ]);
   });
+
+  describe('with TypeScript files', () => {
+    beforeEach(() => {
+      ({ packageJSON, prompts, run } = setupMigrationTest('webdriverio', {
+        mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) },
+        filePaths: ['test/bar.ts']
+      }));
+    });
+
+    it('transforms sdk imports for TypeScript', async () => {
+      await Migrate('@percy/webdriverio', '--skip-cli');
+
+      expect(prompts[2]).toEqual({
+        type: 'confirm',
+        name: 'doTransform',
+        message: 'SDK exports have changed, update imports?',
+        default: true
+      });
+
+      expect(run[jscodeshiftbin].calls[0].args).toEqual([
+        `--transform=${require.resolve('../../transforms/import-default')}`,
+        '--percy-installed=@percy/webdriverio',
+        '--parser=ts',
+        '--percy-sdk=@percy/webdriverio',
+        'test/bar.ts'
+      ]);
+
+      expect(logger.stderr).toEqual([]);
+      expect(logger.stdout).toEqual([
+        '[percy] Migration complete!\n'
+      ]);
+    });
+  });
 });

--- a/test/migrations/webdriverio.test.js
+++ b/test/migrations/webdriverio.test.js
@@ -1,5 +1,4 @@
 import expect from 'expect';
-import globby from 'globby';
 import {
   Migrate,
   logger,
@@ -12,7 +11,8 @@ describe('Migrations - @percy/webdriverio', () => {
 
   beforeEach(() => {
     ({ packageJSON, prompts, run } = setupMigrationTest('webdriverio', {
-      mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) }
+      mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) },
+      filePaths: ['test/foo.js', 'test/bar.js', 'test/bazz.js']
     }));
   });
 
@@ -49,7 +49,9 @@ describe('Migrations - @percy/webdriverio', () => {
       `--transform=${require.resolve('../../transforms/import-default')}`,
       '--percy-installed=@percy/webdriverio',
       '--percy-sdk=@percy/webdriverio',
-      ...(await globby('test/**/*.js').then(f => f.sort()))
+      'test/foo.js',
+      'test/bar.js',
+      'test/bazz.js'
     ]);
 
     expect(logger.stderr).toEqual([]);
@@ -73,7 +75,9 @@ describe('Migrations - @percy/webdriverio', () => {
     expect(run[jscodeshiftbin].calls[0].args).toEqual([
       `--transform=${require.resolve('../../transforms/import-default')}`,
       '--percy-sdk=@percy/webdriverio',
-      ...(await globby('test/**/*.js').then(f => f.sort()))
+      'test/foo.js',
+      'test/bar.js',
+      'test/bazz.js'
     ]);
 
     expect(logger.stderr).toEqual([

--- a/test/migrations/webdriverio.test.js
+++ b/test/migrations/webdriverio.test.js
@@ -11,8 +11,7 @@ describe('Migrations - @percy/webdriverio', () => {
 
   beforeEach(() => {
     ({ packageJSON, prompts, run } = setupMigrationTest('webdriverio', {
-      mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) },
-      filePaths: ['test/foo.js', 'test/bar.js', 'test/bazz.js']
+      mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) }
     }));
   });
 
@@ -92,7 +91,7 @@ describe('Migrations - @percy/webdriverio', () => {
     beforeEach(() => {
       ({ packageJSON, prompts, run } = setupMigrationTest('webdriverio', {
         mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) },
-        filePaths: ['test/bar.ts']
+        mockPrompts: { filePaths: ['test/bar.ts'] }
       }));
     });
 

--- a/test/transforms/import-default.test.js
+++ b/test/transforms/import-default.test.js
@@ -16,6 +16,19 @@ describe('Transforms - import-default.js', () => {
     `);
   });
 
+  it('transforms TypeScript named imports into TS imports', () => {
+    expect(applyTransform(transform, {
+      'percy-installed': '@percy/sdk-old',
+      'percy-sdk': '@percy/sdk-new'
+    }, dedent`
+      import { percySnapshot } from '@percy/sdk-old';
+      import { percySnapshot as psnap } from '@percy/sdk-old';
+    `, 'test/bar.ts')).toEqual(dedent`
+      import * as percySnapshot from '@percy/sdk-new';
+      import * as psnap from '@percy/sdk-new';
+    `);
+  });
+
   it('transforms required variables', () => {
     expect(applyTransform(transform, {
       'percy-sdk': '@percy/sdk',

--- a/transforms/import-default.js
+++ b/transforms/import-default.js
@@ -5,7 +5,7 @@
  * --percy-installed=NAME  installed SDK package name (default: --percy-sdk)
  * --print-options=JSON    output print options (default: {"quote":"single","lineTerminator":"\n"})
 */
-export default function({ source }, { j }, options) {
+export default function({ path, source }, { j }, options) {
   let sdk = options['percy-sdk'];
   if (!sdk) throw new Error('--percy-sdk is required');
 
@@ -20,7 +20,13 @@ export default function({ source }, { j }, options) {
     ))
     .forEach(({ value: node }) => {
       let local = node.specifiers[0].local.name;
-      node.specifiers = [j.importDefaultSpecifier(j.identifier(local))];
+
+      if (path.endsWith('.ts')) {
+        node.specifiers = [j.importNamespaceSpecifier(j.identifier(local))];
+      } else {
+        node.specifiers = [j.importDefaultSpecifier(j.identifier(local))];
+      }
+
       node.source.value = sdk;
     });
 


### PR DESCRIPTION
## Purpose

While testing this package with OSS projects that use Percy SDKs, I discovered the transforms don't automatically handle TS files like we assumed. The first step to fix this was to remove `ts` from the default transform glob (since it never worked) (#51). It also become apparent the transform would need to change too, since TypeScript has it's own import style (`import * as ...`). 

This PR now implements proper transform support for TS files.

## Approach

Since all JS is valid TS, if we detect a `.ts` file, we will pass along the `--parser=ts` flag to `jscodeshift`. Next up, if the file path ends in`.ts`, the transform will change the import to use the TS style default import:

```js
// old
import { percySnapshot } from '@percy/sdk';

// new
import * as percySnapshot from '@percy/sdk';
```