### PR TITLE
✨ Add @percy/cypress migration

### DIFF
--- a/src/migrations/cypress.js
+++ b/src/migrations/cypress.js
@@ -11,7 +11,7 @@ class CypressMigration extends SDKMigration {
   }
 
   transforms = [{
-    message: 'Percy tasks were removed, update plugins file?',
+    message: 'Percy tasks were removed, update Cypress plugins file?',
     default: 'cypress/plugins/index.js',
     async transform(paths) {
       await run(require.resolve('jscodeshift/bin/jscodeshift'), [

--- a/src/migrations/cypress.js
+++ b/src/migrations/cypress.js
@@ -1,0 +1,25 @@
+import path from 'path';
+import { run, npm } from '../utils';
+import SDKMigration from './base';
+
+class CypressMigration extends SDKMigration {
+  static name = '@percy/cypress';
+  static version = '^3.0.0';
+
+  async upgrade() {
+    await npm.install(`${this.name}@${this.version}`);
+  }
+
+  transforms = [{
+    message: 'Percy tasks were removed, update plugins file?',
+    default: 'cypress/plugins/index.js',
+    async transform(paths) {
+      await run(require.resolve('jscodeshift/bin/jscodeshift'), [
+        `--transform=${path.resolve(__dirname, '../../transforms/cypress-plugins.js')}`,
+        ...paths
+      ]);
+    }
+  }];
+};
+
+module.exports = CypressMigration;

--- a/src/migrations/index.js
+++ b/src/migrations/index.js
@@ -1,4 +1,5 @@
 module.exports = [
+  require('./cypress'),
   require('./testcafe'),
   require('./puppeteer'),
   require('./nightmare'),

--- a/test/migrations/cypress.test.js
+++ b/test/migrations/cypress.test.js
@@ -41,7 +41,7 @@ describe('Migrations - @percy/cypress', () => {
     expect(prompts[2]).toEqual({
       type: 'confirm',
       name: 'doTransform',
-      message: 'Percy tasks were removed, update plugins file?',
+      message: 'Percy tasks were removed, update Cypress plugins file?',
       default: true
     });
 
@@ -64,7 +64,7 @@ describe('Migrations - @percy/cypress', () => {
     expect(prompts[2]).toEqual({
       type: 'confirm',
       name: 'doTransform',
-      message: 'Percy tasks were removed, update plugins file?',
+      message: 'Percy tasks were removed, update Cypress plugins file?',
       default: true
     });
 

--- a/test/migrations/cypress.test.js
+++ b/test/migrations/cypress.test.js
@@ -1,0 +1,83 @@
+import expect from 'expect';
+import {
+  Migrate,
+  logger,
+  setupMigrationTest
+} from '../helpers';
+
+describe('Migrations - @percy/cypress', () => {
+  let jscodeshiftbin = require.resolve('jscodeshift/bin/jscodeshift');
+  let packageJSON, prompts, run;
+
+  beforeEach(() => {
+    ({ packageJSON, prompts, run } = setupMigrationTest('cypress', {
+      mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) },
+      mockPrompts: { filePaths: ['cypress/plugins/index.js'] }
+    }));
+  });
+
+  it('upgrades the sdk', async () => {
+    await Migrate('@percy/cypress', '--skip-cli');
+
+    expect(prompts[1]).toEqual({
+      type: 'confirm',
+      name: 'upgradeSDK',
+      message: 'Upgrade SDK to @percy/cypress@^3.0.0?',
+      default: true
+    });
+
+    expect(run.npm.calls[0].args)
+      .toEqual(['install', '--save-dev', '@percy/cypress@^3.0.0']);
+
+    expect(logger.stderr).toEqual([]);
+    expect(logger.stdout).toEqual([
+      '[percy] Migration complete!\n'
+    ]);
+  });
+
+  it('removes tasks from plugins', async () => {
+    await Migrate('@percy/cypress', '--skip-cli');
+
+    expect(prompts[2]).toEqual({
+      type: 'confirm',
+      name: 'doTransform',
+      message: 'Percy tasks were removed, update plugins file?',
+      default: true
+    });
+
+    expect(run[jscodeshiftbin].calls[0].args).toEqual([
+      `--transform=${require.resolve('../../transforms/cypress-plugins.js')}`,
+      'cypress/plugins/index.js'
+    ]);
+
+    expect(logger.stderr).toEqual([]);
+    expect(logger.stdout).toEqual([
+      '[percy] Migration complete!\n'
+    ]);
+  });
+
+  it('asks to remove tasks even when not installed', async () => {
+    delete packageJSON.devDependencies;
+
+    await Migrate('@percy/cypress', '--skip-cli');
+
+    expect(prompts[2]).toEqual({
+      type: 'confirm',
+      name: 'doTransform',
+      message: 'Percy tasks were removed, update plugins file?',
+      default: true
+    });
+
+    expect(run[jscodeshiftbin].calls[0].args).toEqual([
+      `--transform=${require.resolve('../../transforms/cypress-plugins')}`,
+      'cypress/plugins/index.js'
+    ]);
+
+    expect(logger.stderr).toEqual([
+      '[percy] The specified SDK was not found in your dependencies\n'
+    ]);
+    expect(logger.stdout).toEqual([
+      '[percy] Migration complete!\n'
+    ]);
+  });
+});

--- a/test/transforms/cypress-plugins.test.js
+++ b/test/transforms/cypress-plugins.test.js
@@ -1,0 +1,48 @@
+import expect from 'expect';
+import applyTransform, { dedent } from '../helpers/apply-transform';
+import transform from '../../transforms/cypress-plugins';
+
+describe('Transforms - cypress-plugins.js', () => {
+  it('removes common task usage', () => {
+    expect(applyTransform(transform, {}, dedent`
+      const someOtherTask = require('some-other-package');
+      const percyHealthCheck = require('@percy/cypress/task');
+
+      module.exports = (on, config) => {
+        on('task', someOtherTask);
+        on('task', percyHealthCheck);
+        on('task', require('some-other-task'));
+        on('task', require('@percy/cypress/task'));
+        return config;
+      };
+    `)).toEqual(dedent`
+      const someOtherTask = require('some-other-package');
+
+      module.exports = (on, config) => {
+        on('task', someOtherTask);
+        on('task', require('some-other-task'));
+        return config;
+      };
+    `);
+  });
+
+  it('removes module task usage', () => {
+    expect(applyTransform(transform, {}, dedent`
+      import someOtherTask from 'some-other-package';
+      import percyHealthCheck from '@percy/cypress/task';
+
+      export default (on, config) => {
+        on('task', someOtherTask);
+        on('task', percyHealthCheck);
+        return config;
+      };
+    `)).toEqual(dedent`
+      import someOtherTask from 'some-other-package';
+
+      export default (on, config) => {
+        on('task', someOtherTask);
+        return config;
+      };
+    `);
+  });
+});

--- a/transforms/cypress-plugins.js
+++ b/transforms/cypress-plugins.js
@@ -1,0 +1,52 @@
+/**
+ * Transforms cypress/plugins/index.js to remove @percy/cypress/task usage.
+ *
+ * --print-options=JSON    output print options (default: {"quote":"single","lineTerminator":"\n"})
+*/
+export default function({ source }, { j }, options) {
+  let root = j(source);
+  let local;
+
+  // - import <local> from '@percy/cypress/task'
+  root
+    .find(j.ImportDeclaration, node => (
+      node.source.value === '@percy/cypress/task'
+    ))
+    .forEach(({ value: node }) => {
+      local = node.specifiers[0].local.name;
+    })
+    .remove();
+
+  // - const <local> = require('@percy/cypress/task')
+  root
+    .find(j.VariableDeclarator, node => (
+      node.init.type === 'CallExpression' &&
+      node.init.callee.name === 'require' &&
+      node.init.arguments[0].value === '@percy/cypress/task'
+    ))
+    .forEach(({ value: node }) => {
+      local = node.id.name;
+    })
+    .remove();
+
+  // - on('task', <local>)
+  // - on('task', require('@percy/cypress/task'))
+  root
+    .find(j.CallExpression, node => (
+      node.callee.name === 'on' &&
+      node.arguments[0].type === 'Literal' &&
+      node.arguments[0].value === 'task' &&
+      ((node.arguments[1].type === 'Identifier' &&
+        node.arguments[1].name === local) ||
+       (node.arguments[1].type === 'CallExpression' &&
+        node.arguments[1].callee.name === 'require' &&
+        node.arguments[1].arguments[0].value === '@percy/cypress/task'))
+    ))
+    .remove();
+
+  return root.toSource({
+    quote: 'single',
+    lineTerminator: '\n',
+    ...options['print-options']
+  });
+}


### PR DESCRIPTION
## What is this?

This adds a migration for `@percy/cypress`. This SDK does not have import changes, but does have a major change removing the need for task registration. A new transform was added to handle this task removal for users. 

I'm not sure if you can define tasks using ES modules in Cypress, but I added logic and tests for it just in case.

```diff
- import <local> from '@percy/cypress/task'
- const <local> = require('@percy/cypress/task')

- on('task', <local>)
- on('task', require('@percy/cypress/task'))
```