### PR TITLE
🐛 Fix Cypress transform AST traversal

### DIFF
--- a/test/transforms/cypress-plugins.test.js
+++ b/test/transforms/cypress-plugins.test.js
@@ -45,4 +45,17 @@ describe('Transforms - cypress-plugins.js', () => {
       };
     `);
   });
+
+  it('does not error when encountering unexpected trees', () => {
+    expect(applyTransform(transform, {}, dedent`
+      let percyHealthCheck = require('@percy/cypress/task');
+      let foo = on('task'); // callee one args
+      let bar = on(); // callee with no args
+      let baz; // declaration with no init
+    `)).toEqual(dedent`
+      let foo = on('task'); // callee one args
+      let bar = on(); // callee with no args
+      let baz; // declaration with no init
+    `);
+  });
 });

--- a/transforms/cypress-plugins.js
+++ b/transforms/cypress-plugins.js
@@ -20,7 +20,7 @@ export default function({ source }, { j }, options) {
   // - const <local> = require('@percy/cypress/task')
   root
     .find(j.VariableDeclarator, node => (
-      node.init.type === 'CallExpression' &&
+      node.init?.type === 'CallExpression' &&
       node.init.callee.name === 'require' &&
       node.init.arguments[0].value === '@percy/cypress/task'
     ))
@@ -34,11 +34,11 @@ export default function({ source }, { j }, options) {
   root
     .find(j.CallExpression, node => (
       node.callee.name === 'on' &&
-      node.arguments[0].type === 'Literal' &&
+      node.arguments[0]?.type === 'Literal' &&
       node.arguments[0].value === 'task' &&
-      ((node.arguments[1].type === 'Identifier' &&
+      ((node.arguments[1]?.type === 'Identifier' &&
         node.arguments[1].name === local) ||
-       (node.arguments[1].type === 'CallExpression' &&
+       (node.arguments[1]?.type === 'CallExpression' &&
         node.arguments[1].callee.name === 'require' &&
         node.arguments[1].arguments[0].value === '@percy/cypress/task'))
     ))


### PR DESCRIPTION
## What is this?

The initial implementation of the Cypress transform forgot to account for instances where some properties of an AST node do not exist. Such as variable declarations without initial values, or calling `on()` with less than the expected number of arguments (although arguments are required for that function).