### PR TITLE
 ✨ Transform improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "@percy/config": "^1.0.0-beta.36",
     "@percy/logger": "^1.0.0-beta.36",
     "cross-spawn": "^7.0.3",
-    "globby": "^11.0.2",
     "inquirer": "^8.0.0",
+    "inquirer-glob-prompt": "^0.1.0",
     "jscodeshift": "^0.11.0",
     "semver": "^7.3.4"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -221,6 +221,10 @@ class Migrate extends Command {
   // Confirms running available SDK transforms
   async confirmTransforms(sdk) {
     for (let t of sdk.transforms) {
+      if (sdk.installed && t.when?.(sdk.installed) === false) {
+        continue;
+      }
+
       let { doTransform } = await inquirer.prompt([{
         type: 'confirm',
         name: 'doTransform',

--- a/src/index.js
+++ b/src/index.js
@@ -3,10 +3,11 @@ import Command, { flags } from '@oclif/command';
 import PercyConfig from '@percy/config';
 import logger from '@percy/logger';
 import inquirer from 'inquirer';
-import globby from 'globby';
 import inspectDeps from './inspect';
 import migrations from './migrations';
 import { run, npm } from './utils';
+
+inquirer.registerPrompt('glob', require('inquirer-glob-prompt'));
 
 class Migrate extends Command {
   static description = 'Upgrade and migrate your Percy SDK to the latest version';
@@ -232,11 +233,13 @@ class Migrate extends Command {
       }
 
       let { filePaths } = await inquirer.prompt([{
-        type: 'input',
+        type: 'glob',
         name: 'filePaths',
         message: 'Which files?',
         default: t.default,
-        filter: glob => globby(glob)
+        glob: {
+          ignore: 'node_modules'
+        }
       }]);
 
       if (!filePaths?.length) {

--- a/src/migrations/cypress.js
+++ b/src/migrations/cypress.js
@@ -1,4 +1,5 @@
 import path from 'path';
+import semver from 'semver';
 import { run, npm } from '../utils';
 import SDKMigration from './base';
 
@@ -13,6 +14,7 @@ class CypressMigration extends SDKMigration {
   transforms = [{
     message: 'Percy tasks were removed, update Cypress plugins file?',
     default: 'cypress/plugins/index.js',
+    when: i => semver.satisfies(i.version, '2 - 3'),
     async transform(paths) {
       await run(require.resolve('jscodeshift/bin/jscodeshift'), [
         `--transform=${path.resolve(__dirname, '../../transforms/cypress-plugins.js')}`,

--- a/test/helpers/mock-prompts.js
+++ b/test/helpers/mock-prompts.js
@@ -2,6 +2,7 @@ import inquirer from 'inquirer';
 
 // Mock prompts by stubbing the inquirer.prompt function
 export default function mockPrompts(answers) {
+  let props = Object.getOwnPropertyDescriptors(inquirer.prompt);
   let prompts = [];
 
   inquirer.prompt = async questions => {
@@ -17,5 +18,6 @@ export default function mockPrompts(answers) {
     return result;
   };
 
+  Object.defineProperties(inquirer.prompt, props);
   return prompts;
 }

--- a/test/helpers/setup-migration.js
+++ b/test/helpers/setup-migration.js
@@ -7,7 +7,7 @@ import mockCommands from './mock-commands';
 export default function setupMigrationTest(filename, mocks) {
   let packageJSON = mockPackageJSON({
     devDependencies: {
-      [require(`../../src/migrations/${filename}`).name]: '0.0.0'
+      [require(`../../src/migrations/${filename}`).name]: mocks.version || '0.0.0'
     }
   });
 

--- a/test/migrations/cypress.test.js
+++ b/test/migrations/cypress.test.js
@@ -11,6 +11,7 @@ describe('Migrations - @percy/cypress', () => {
 
   beforeEach(() => {
     ({ packageJSON, prompts, run } = setupMigrationTest('cypress', {
+      version: '2.1.3',
       mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) },
       mockPrompts: { filePaths: ['cypress/plugins/index.js'] }
     }));
@@ -76,6 +77,20 @@ describe('Migrations - @percy/cypress', () => {
     expect(logger.stderr).toEqual([
       '[percy] The specified SDK was not found in your dependencies\n'
     ]);
+    expect(logger.stdout).toEqual([
+      '[percy] Migration complete!\n'
+    ]);
+  });
+
+  it('does not ask to remove tasks for older versions', async () => {
+    packageJSON.devDependencies['@percy/cypress'] = '1.0.0';
+
+    await Migrate('@percy/cypress', '--skip-cli');
+
+    expect(prompts[2]).toBeUndefined();
+    expect(run[jscodeshiftbin].calls).toBeUndefined();
+
+    expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
       '[percy] Migration complete!\n'
     ]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2418,7 +2418,7 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
-figures@^3.0.0:
+figures@^3.0.0, figures@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
   integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
@@ -2713,7 +2713,7 @@ globby@^10.0.1:
     merge2 "^1.2.3"
     slash "^3.0.0"
 
-globby@^11.0.1, globby@^11.0.2:
+globby@^11.0.1, globby@^11.0.3:
   version "11.0.3"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.3.tgz#9b1f0cb523e171dd1ad8c7b2a9fb4b644b9593cb"
   integrity sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==
@@ -2887,6 +2887,16 @@ inherits@2, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+inquirer-glob-prompt@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/inquirer-glob-prompt/-/inquirer-glob-prompt-0.1.0.tgz#3676bc10bcdd31e17121146be9c6467a2d79fc85"
+  integrity sha512-Zw9XYJdrBBJ5TZjLH8Nu8PIa54huvkP0xeNOTtKh3bis0DNAJWMtdpT9PIJBkqheMUnwIPmv8jkjOr7aPKYFqg==
+  dependencies:
+    chalk "^4.1.0"
+    figures "^3.2.0"
+    globby "^11.0.3"
+    rxjs "^6.6.7"
 
 inquirer@^8.0.0:
   version "8.0.0"
@@ -4419,6 +4429,13 @@ rxjs@^6.6.6:
   version "6.6.6"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.6.tgz#14d8417aa5a07c5e633995b525e1e3c0dec03b70"
   integrity sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.6.7:
+  version "6.6.7"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
+  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
## What is this?

This improves transform prompts in two ways

1. Uses [`inquirer-glob-prompt`](https://github.com/wwilsman/inquirer-glob-prompt#readme) to prompt for a glob pattern in a much nicer way.
2. Adds a `transform.when` method that can return false when a transform prompt should be skipped entirely. This check is only performed when an SDK is already installed. When not installed, all transforms are always prompted.

The second addition was utilized to conditionally ask about removing Cypress tasks. In `@percy/cypress < 2`, there were no tasks, so this prompt need only be asked when using v2. The version check uses `2 - 3` as the range in case somebody has already upgraded but accidentally skipped the transform the first time.