### PR TITLE
✨ @percy/ember (ember-percy) migration support

### DIFF
--- a/src/migrations/ember.js
+++ b/src/migrations/ember.js
@@ -1,0 +1,30 @@
+import path from 'path';
+import { run, npm } from '../utils';
+import SDKMigration from './base';
+
+class EmberMigration extends SDKMigration {
+  static name = '@percy/ember';
+  static aliases = ['ember-percy'];
+  static version = '^3.0.0';
+
+  async upgrade() {
+    await npm.install(`${this.name}@${this.version}`);
+  }
+
+  transforms = [{
+    message: 'SDK exports have changed, update imports?',
+    default: '{test,spec}?(s)/**/*.{js,ts}',
+    when: i => i.name === 'ember-percy',
+    async transform(paths) {
+      await run(require.resolve('jscodeshift/bin/jscodeshift'), [
+        `--transform=${path.resolve(__dirname, '../../transforms/import-default.js')}`,
+        this.installed && `--percy-installed=${this.installed.name}`,
+        paths.some((p) => p.endsWith('.ts')) && '--parser=ts',
+        `--percy-sdk=${this.name}`,
+        ...paths
+      ]);
+    }
+  }];
+};
+
+module.exports = EmberMigration;

--- a/src/migrations/index.js
+++ b/src/migrations/index.js
@@ -6,6 +6,7 @@ module.exports = [
   require('./nightwatch'),
   require('./protractor'),
   require('./webdriverio'),
+  require('./ember'),
   require('./selenium-javascript'),
   // non-js
   require('./capybara'),

--- a/test/helpers/setup-migration.js
+++ b/test/helpers/setup-migration.js
@@ -5,9 +5,11 @@ import mockCommands from './mock-commands';
 
 // Setup a migration test by mocking package.json, sdk prompts, and upgrade commands
 export default function setupMigrationTest(filename, mocks) {
+  let { name } = require(`../../src/migrations/${filename}`);
+
   let packageJSON = mockPackageJSON({
     devDependencies: {
-      [require(`../../src/migrations/${filename}`).name]: mocks.version || '0.0.0'
+      [mocks.installed?.name || name]: mocks.installed?.version || '0.0.0'
     }
   });
 

--- a/test/migrations/cypress.test.js
+++ b/test/migrations/cypress.test.js
@@ -11,7 +11,7 @@ describe('Migrations - @percy/cypress', () => {
 
   beforeEach(() => {
     ({ packageJSON, prompts, run } = setupMigrationTest('cypress', {
-      version: '2.1.3',
+      installed: { version: '2.1.3' },
       mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) },
       mockPrompts: { filePaths: ['cypress/plugins/index.js'] }
     }));

--- a/test/migrations/ember.test.js
+++ b/test/migrations/ember.test.js
@@ -1,0 +1,126 @@
+import expect from 'expect';
+import {
+  Migrate,
+  logger,
+  setupMigrationTest
+} from '../helpers';
+
+describe('Migrations - @percy/ember', () => {
+  let jscodeshiftbin = require.resolve('jscodeshift/bin/jscodeshift');
+  let packageJSON, prompts, run;
+
+  beforeEach(() => {
+    ({ packageJSON, prompts, run } = setupMigrationTest('ember', {
+      mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) }
+    }));
+  });
+
+  it('upgrades the sdk', async () => {
+    await Migrate('@percy/ember', '--skip-cli');
+
+    expect(prompts[1]).toEqual({
+      type: 'confirm',
+      name: 'upgradeSDK',
+      message: 'Upgrade SDK to @percy/ember@^3.0.0?',
+      default: true
+    });
+
+    expect(run.npm.calls[0].args)
+      .toEqual(['install', '--save-dev', '@percy/ember@^3.0.0']);
+
+    expect(logger.stderr).toEqual([]);
+    expect(logger.stdout).toEqual([
+      '[percy] Migration complete!\n'
+    ]);
+  });
+
+  it('asks to transform sdk imports when not installed', async () => {
+    delete packageJSON.devDependencies;
+
+    await Migrate('@percy/ember', '--skip-cli');
+
+    expect(prompts[2]).toEqual({
+      type: 'confirm',
+      name: 'doTransform',
+      message: 'SDK exports have changed, update imports?',
+      default: true
+    });
+
+    expect(run[jscodeshiftbin].calls[0].args).toEqual([
+      `--transform=${require.resolve('../../transforms/import-default')}`,
+      '--percy-sdk=@percy/ember',
+      'test/foo.js',
+      'test/bar.js',
+      'test/bazz.js'
+    ]);
+
+    expect(logger.stderr).toEqual([
+      '[percy] The specified SDK was not found in your dependencies\n'
+    ]);
+    expect(logger.stdout).toEqual([
+      '[percy] Migration complete!\n'
+    ]);
+  });
+
+  it('asks to transforms sdk imports when ember-percy is installed', async () => {
+    delete packageJSON.devDependencies['@percy/ember'];
+    packageJSON.devDependencies['ember-percy'] = '1.0.0';
+
+    await Migrate('@percy/ember', '--skip-cli');
+
+    expect(prompts[2]).toEqual({
+      type: 'confirm',
+      name: 'doTransform',
+      message: 'SDK exports have changed, update imports?',
+      default: true
+    });
+
+    expect(run[jscodeshiftbin].calls[0].args).toEqual([
+      `--transform=${require.resolve('../../transforms/import-default')}`,
+      '--percy-installed=ember-percy',
+      '--percy-sdk=@percy/ember',
+      'test/foo.js',
+      'test/bar.js',
+      'test/bazz.js'
+    ]);
+
+    expect(logger.stderr).toEqual([]);
+    expect(logger.stdout).toEqual([
+      '[percy] Migration complete!\n'
+    ]);
+  });
+
+  describe('with TypeScript files', () => {
+    beforeEach(() => {
+      ({ packageJSON, prompts, run } = setupMigrationTest('ember', {
+        installed: { name: 'ember-percy' },
+        mockCommands: { [jscodeshiftbin]: () => ({ status: 0 }) },
+        mockPrompts: { filePaths: ['test/bar.ts'] }
+      }));
+    });
+
+    it('transforms sdk imports for TypeScript', async () => {
+      await Migrate('@percy/ember', '--skip-cli');
+
+      expect(prompts[2]).toEqual({
+        type: 'confirm',
+        name: 'doTransform',
+        message: 'SDK exports have changed, update imports?',
+        default: true
+      });
+
+      expect(run[jscodeshiftbin].calls[0].args).toEqual([
+        `--transform=${require.resolve('../../transforms/import-default')}`,
+        '--percy-installed=ember-percy',
+        '--parser=ts',
+        '--percy-sdk=@percy/ember',
+        'test/bar.ts'
+      ]);
+
+      expect(logger.stderr).toEqual([]);
+      expect(logger.stdout).toEqual([
+        '[percy] Migration complete!\n'
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## What is this?

This adds support for migrating `@percy/ember` (and `ember-percy`) to v3.

The import transform only applies to `ember-percy` so the new `transform.when` method was utilized for this purpose.

I also updated the test helper slightly to be a bit more broader.