### PR TITLE
✨ Add `percy-capybara` migration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,9 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -33,6 +33,9 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node": ">=12"
   },
   "scripts": {
-    "build": "babel --root-mode upward src --out-dir dist",
+    "build": "babel --root-mode upward src --copy-files --out-dir dist",
     "clean": "rm -rf packages/**/{dist,.nyc_output,coverage,oclif.manifest.json}",
     "lint": "eslint --ignore-path .gitignore .",
     "postbuild": "oclif-dev manifest",

--- a/src/inspect.js
+++ b/src/inspect.js
@@ -39,10 +39,14 @@ async function inspectGemFile(info) {
       encoding: 'utf-8'
     });
 
-    let { name, version } = JSON.parse(output);
-    let SDK = migrations.find(SDK => SDK.matches(name, 'ruby'));
-    version = semver.coerce(version)?.version;
-    if (SDK) info.installed.push(new SDK({ name, version }));
+    for (let { name, version } of JSON.parse(output)) {
+      let SDK = migrations.find(SDK => SDK.matches(name, 'ruby'));
+
+      if (SDK) {
+        version = semver.coerce(version)?.version;
+        info.installed.push(new SDK({ name, version }));
+      }
+    }
 
     info.inspected.push('ruby');
   } catch (error) {

--- a/src/inspect.js
+++ b/src/inspect.js
@@ -2,7 +2,7 @@ import semver from 'semver';
 import { resolve } from 'path';
 import logger from '@percy/logger';
 import migrations from './migrations';
-import { execSync } from 'child_process';
+import { run } from './utils';
 
 // Tries to detect the installed SDK by checking the current project's CWD. Checks non-dev deps in
 // addition to dev deps even though SDKs should only be installed as dev deps.
@@ -31,13 +31,11 @@ function inspectPackageJSON(info) {
   }
 }
 
-async function inspectGemFile(info) {
+async function inspectGemfile(info) {
   try {
-    let inspectRuby = resolve(__dirname, './inspect_gemfile.rb');
-    let output = execSync(`ruby ${inspectRuby}`, {
-      stdio: ['ignore', 'pipe', 'ignore'],
-      encoding: 'utf-8'
-    });
+    let output = run('ruby', [
+      resolve(__dirname, './inspect_gemfile.rb')
+    ], true);
 
     for (let { name, version } of JSON.parse(output)) {
       let SDK = migrations.find(SDK => SDK.matches(name, 'ruby'));
@@ -69,7 +67,7 @@ export default function inspectDeps() {
   inspectPackageJSON(info);
 
   // Ruby projects
-  inspectGemFile(info);
+  inspectGemfile(info);
 
   return info;
 }

--- a/src/inspect.js
+++ b/src/inspect.js
@@ -1,5 +1,6 @@
+import fs from 'fs';
+import path from 'path';
 import semver from 'semver';
-import { resolve } from 'path';
 import logger from '@percy/logger';
 import migrations from './migrations';
 import { run } from './utils';
@@ -32,9 +33,16 @@ function inspectPackageJSON(info) {
 }
 
 async function inspectGemfile(info) {
+  let log = logger('migrate:inspect:ruby');
+
   try {
+    if (!fs.existsSync(path.join(process.cwd(), 'Gemfile'))) {
+      log.debug('Could not find Gemfile in current directory');
+      return;
+    }
+
     let output = run('ruby', [
-      resolve(__dirname, './inspect_gemfile.rb')
+      path.join(__dirname, 'inspect_gemfile.rb')
     ], true);
 
     for (let { name, version } of JSON.parse(output)) {
@@ -48,7 +56,6 @@ async function inspectGemfile(info) {
 
     info.inspected.push('ruby');
   } catch (error) {
-    let log = logger('migrate:inspect:ruby');
     log.error('Encountered an error inspecting Gemfile');
     log.error(error);
   }

--- a/src/inspect.js
+++ b/src/inspect.js
@@ -39,12 +39,12 @@ async function inspectGemFile(info) {
       encoding: 'utf-8'
     });
 
-    info.inspected.push('ruby');
     let { name, version } = JSON.parse(output);
     let SDK = migrations.find(SDK => SDK.matches(name, 'ruby'));
+    version = semver.coerce(version)?.version;
+    if (SDK) info.installed.push(new SDK({ name, version }));
 
-    version = semver.coerce(version).version;
-    if (SDK && version !== '0.0.0') info.installed.push(new SDK({ name, version }));
+    info.inspected.push('ruby');
   } catch (error) {
     let log = logger('migrate:inspect:ruby');
     log.error('Encountered an error inspecting Gemfile');

--- a/src/inspect.js
+++ b/src/inspect.js
@@ -40,9 +40,6 @@ async function inspectGemFile(info) {
     });
 
     info.inspected.push('ruby');
-
-    if (!output) return;
-
     let { name, version } = JSON.parse(output);
     let SDK = migrations.find(SDK => SDK.matches(name, 'ruby'));
 

--- a/src/inspect_gemfile.rb
+++ b/src/inspect_gemfile.rb
@@ -1,12 +1,13 @@
 require 'bundler'
+require 'json'
 
-return puts '{}' if !File.directory?("#{Dir.pwd}/Gemfile")
+return puts '[]' unless File.exist?("#{Dir.pwd}/Gemfile")
 
 deps = Bundler::Definition.build("#{Dir.pwd}/Gemfile", nil, {}).dependencies
-found = deps.detect { |dep| dep.name == "percy-capybara" }
 
-if found
-  puts %Q[{ "name": "#{found.name}", "version": "#{found.requirement.as_list.first}" }]
-else
-  puts '{}'
+found = deps.reduce([]) do |all, dep|
+  next all unless dep.name.start_with? "percy-"
+  all << { name: dep.name, version: dep.requirement.as_list.first }
 end
+
+puts found.to_json

--- a/src/inspect_gemfile.rb
+++ b/src/inspect_gemfile.rb
@@ -1,14 +1,14 @@
 require 'bundler'
 
-empty = '{ "version": "0.0" }'
-
-return puts empty if !File.directory?("#{Dir.pwd}/Gemfile")
+return puts '{}' if !File.directory?("#{Dir.pwd}/Gemfile")
 
 deps = Bundler::Definition.build("#{Dir.pwd}/Gemfile", nil, {}).dependencies
+
 deps.each do |dep|
   if dep.name == "percy-capybara"
     puts %Q[{ "name": "#{dep.name}", "version": "#{dep.requirement.as_list.first}" }]
+    break
   else
-    puts empty
+    puts '{}'
   end
 end

--- a/src/inspect_gemfile.rb
+++ b/src/inspect_gemfile.rb
@@ -1,8 +1,6 @@
 require 'bundler'
 require 'json'
 
-return puts '[]' unless File.exist?("#{Dir.pwd}/Gemfile")
-
 deps = Bundler::Definition.build("#{Dir.pwd}/Gemfile", nil, {}).dependencies
 
 found = deps.reduce([]) do |all, dep|

--- a/src/inspect_gemfile.rb
+++ b/src/inspect_gemfile.rb
@@ -1,0 +1,11 @@
+require 'bundler'
+
+# @TODO actually get the right path
+deps = Bundler::Definition.build("#{Dir.pwd}/Gemfile", nil, {}).dependencies
+deps.each do |dep|
+  if dep.name == "percy-capybara"
+    puts %Q[{ "name": "#{dep.name}", "version": "#{dep.requirement.as_list.first}" }]
+  else
+    puts '{}'
+  end
+end

--- a/src/inspect_gemfile.rb
+++ b/src/inspect_gemfile.rb
@@ -3,12 +3,10 @@ require 'bundler'
 return puts '{}' if !File.directory?("#{Dir.pwd}/Gemfile")
 
 deps = Bundler::Definition.build("#{Dir.pwd}/Gemfile", nil, {}).dependencies
+found = deps.detect { |dep| dep.name == "percy-capybara" }
 
-deps.each do |dep|
-  if dep.name == "percy-capybara"
-    puts %Q[{ "name": "#{dep.name}", "version": "#{dep.requirement.as_list.first}" }]
-    break
-  else
-    puts '{}'
-  end
+if found
+  puts %Q[{ "name": "#{found.name}", "version": "#{found.requirement.as_list.first}" }]
+else
+  puts '{}'
 end

--- a/src/inspect_gemfile.rb
+++ b/src/inspect_gemfile.rb
@@ -1,11 +1,14 @@
 require 'bundler'
 
-# @TODO actually get the right path
+empty = '{ "version": "0.0" }'
+
+return puts empty if !File.directory?("#{Dir.pwd}/Gemfile")
+
 deps = Bundler::Definition.build("#{Dir.pwd}/Gemfile", nil, {}).dependencies
 deps.each do |dep|
   if dep.name == "percy-capybara"
     puts %Q[{ "name": "#{dep.name}", "version": "#{dep.requirement.as_list.first}" }]
   else
-    puts '{}'
+    puts empty
   end
 end

--- a/src/migrations/capybara.js
+++ b/src/migrations/capybara.js
@@ -1,9 +1,32 @@
+import path from 'path';
 import SDKMigration from './base';
+import { codeshift, run } from '../utils';
 
 class CapybaraMigration extends SDKMigration {
   static language = 'ruby';
   static name = 'percy-capybara';
   static version = '^5.0.0';
-};
+
+  async upgrade() {
+    try {
+      await run('bundle', ['remove', 'percy-capybara']);
+    } catch (err) {
+      // couldn't remove the package / it doesn't exist
+    }
+
+    await run('bundle', ['add', 'percy-capybara', '--version=~> 5.0.0']);
+  }
+
+  transforms = [{
+    message: 'The Capybara API has breaking changes, automatically convert to the new API?',
+    default: '{spec}?(s)/**/*.rb',
+    async transform(paths) {
+      await codeshift.run('ruby', [
+        `--transform=${path.resolve(__dirname, '../../transforms/capybara.rb')}`,
+        ...paths
+      ]);
+    }
+  }];
+}
 
 module.exports = CapybaraMigration;

--- a/src/utils.js
+++ b/src/utils.js
@@ -93,5 +93,10 @@ export const codeshift = {
     install: () => codeshift.install('js', 'node_modules/jscodeshift/bin/jscodeshift.js', () => {
       return run('npm', [`--prefix=${codeshift.path}/js`, 'install', 'jscodeshift']);
     })
+  },
+  ruby: {
+    install: () => codeshift.install('ruby', 'bin/codeshift', () => {
+      return run('gem', ['install', 'codeshift', `--install-dir=${codeshift.path}/ruby`, '--no-document']);
+    })
   }
 };

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -1,3 +1,4 @@
+import path from 'path';
 import mockRequire from 'mock-require';
 
 // Run migrate after re-requiring specific modules
@@ -17,4 +18,24 @@ export function mockPackageJSON(pkg) {
 export function mockConfigSearch(search) {
   mockRequire('@percy/config', { search });
   mockRequire.reRequire('@percy/config');
+}
+
+// Mock the inspect_gemfile.rb script
+export function mockInspectGemfile(output) {
+  let inspectCmd = `ruby ${path.resolve(__dirname, '../../src/inspect_gemfile.rb')}`;
+  let { execSync } = require('child_process');
+  let ret = { output };
+
+  mockRequire('child_process', {
+    execSync: (cmda, options) => {
+      if (cmda === inspectCmd) {
+        return JSON.stringify(ret.output);
+      } else {
+        return execSync(cmda, options);
+      }
+    }
+  });
+
+  mockRequire.reRequire('../../src/inspect');
+  return ret;
 }

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import path from 'path';
 import mockRequire from 'mock-require';
 
@@ -20,22 +21,8 @@ export function mockConfigSearch(search) {
   mockRequire.reRequire('@percy/config');
 }
 
-// Mock the inspect_gemfile.rb script
-export function mockInspectGemfile(output) {
-  let inspectCmd = `ruby ${path.resolve(__dirname, '../../src/inspect_gemfile.rb')}`;
-  let { execSync } = require('child_process');
-  let ret = { output };
-
-  mockRequire('child_process', {
-    execSync: (cmda, options) => {
-      if (cmda === inspectCmd) {
-        return JSON.stringify(ret.output);
-      } else {
-        return execSync(cmda, options);
-      }
-    }
-  });
-
-  mockRequire.reRequire('../../src/inspect');
-  return ret;
+// "Mock" a Gemfile by actually writing one to the current directory
+export function mockGemfile(contents) {
+  let file = mockGemfile.filepath = path.join(process.cwd(), 'Gemfile');
+  fs.writeFileSync(file, [].concat(contents).join('\n'));
 }

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -1,6 +1,7 @@
+import fs from 'fs';
 import logger from '@percy/logger/test/helper';
 import mockRequire from 'mock-require';
-import { mockConfigSearch } from './common';
+import { mockConfigSearch, mockGemfile } from './common';
 import mockCommands from './mock-commands';
 
 // common hooks
@@ -16,6 +17,11 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  if (mockGemfile.filepath) {
+    fs.unlinkSync(mockGemfile.filepath);
+    delete mockGemfile.filepath;
+  }
+
   process.removeAllListeners();
   mockRequire.stopAll();
 });

--- a/test/helpers/mock-commands.js
+++ b/test/helpers/mock-commands.js
@@ -19,13 +19,5 @@ export default function mockCommands(cmds) {
     }
   });
 
-  mockRequire('child_process', {
-    execSync: (cmd, args, options) => {
-      // match the ruby scripts output
-      // eslint-disable-next-line
-      return `{ \"name\": \"percy-capybara\", \"version\": \"0.0.0\" }`;
-    }
-  });
-
   return cmds;
 }

--- a/test/helpers/mock-commands.js
+++ b/test/helpers/mock-commands.js
@@ -19,5 +19,13 @@ export default function mockCommands(cmds) {
     }
   });
 
+  mockRequire('child_process', {
+    execSync: (cmd, args, options) => {
+      // match the ruby scripts output
+      // eslint-disable-next-line
+      return `{ \"name\": \"percy-capybara\", \"version\": \"0.0.0\" }`;
+    }
+  });
+
   return cmds;
 }

--- a/test/helpers/setup-codeshift.js
+++ b/test/helpers/setup-codeshift.js
@@ -2,4 +2,5 @@ import { codeshift } from '../../src/utils';
 
 (async function() {
   await codeshift.js?.install();
+  await codeshift.ruby?.install();
 })();

--- a/test/helpers/setup-migration.js
+++ b/test/helpers/setup-migration.js
@@ -17,10 +17,10 @@ export default function setupMigrationTest(filename, mocks) {
   });
 
   let inspectGemfile = mockInspectGemfile(
-    language !== 'ruby' ? {} : {
+    language !== 'ruby' ? [] : [{
       name: mocks.installed?.name || name,
-      version: mocks.installed?.version || '0.0.0'
-    }
+      version: mocks.installed?.version || '= 0'
+    }]
   );
 
   let prompts = mockPrompts({

--- a/test/helpers/setup-migration.js
+++ b/test/helpers/setup-migration.js
@@ -21,17 +21,17 @@ export default function setupMigrationTest(filename, mocks) {
     ...mocks.mockPrompts
   });
 
+  let run = mockCommands({
+    npm: () => ({ status: 0 }),
+    ...mocks.mockCommands
+  });
+
   mockRequire('child_process', {
     execSync: (cmd, args, options) => {
       // match the ruby scripts output
       // eslint-disable-next-line
       return `{ \"name\": \"percy-capybara\", \"version\": \"${mocks.installed?.version || '0.0.0'}\" }`;
     }
-  });
-
-  let run = mockCommands({
-    npm: () => ({ status: 0 }),
-    ...mocks.mockCommands
   });
 
   mockRequire('fs', {

--- a/test/helpers/setup-migration.js
+++ b/test/helpers/setup-migration.js
@@ -1,7 +1,7 @@
 import mockRequire from 'mock-require';
 import {
   mockPackageJSON,
-  mockInspectGemfile
+  mockGemfile
 } from './common';
 import mockPrompts from './mock-prompts';
 import mockCommands from './mock-commands';
@@ -16,12 +16,11 @@ export default function setupMigrationTest(filename, mocks) {
     }
   });
 
-  let inspectGemfile = mockInspectGemfile(
-    language !== 'ruby' ? [] : [{
-      name: mocks.installed?.name || name,
-      version: mocks.installed?.version || '= 0'
-    }]
-  );
+  if (language === 'ruby') {
+    mockGemfile(
+      `gem '${mocks.installed?.name || name}', ` +
+        `'${mocks.installed?.version || 0}'`);
+  }
 
   let prompts = mockPrompts({
     isSDK: true,
@@ -45,5 +44,5 @@ export default function setupMigrationTest(filename, mocks) {
   mockRequire.reRequire(`../../src/migrations/${filename}`);
   mockRequire.reRequire('../../src/migrations');
 
-  return { packageJSON, inspectGemfile, prompts, run };
+  return { packageJSON, prompts, run };
 }

--- a/test/helpers/setup-migration.js
+++ b/test/helpers/setup-migration.js
@@ -21,6 +21,14 @@ export default function setupMigrationTest(filename, mocks) {
     ...mocks.mockPrompts
   });
 
+  mockRequire('child_process', {
+    execSync: (cmd, args, options) => {
+      // match the ruby scripts output
+      // eslint-disable-next-line
+      return `{ \"name\": \"percy-capybara\", \"version\": \"${mocks.installed?.version || '0.0.0'}\" }`;
+    }
+  });
+
   let run = mockCommands({
     npm: () => ({ status: 0 }),
     ...mocks.mockCommands

--- a/test/helpers/setup-migration.js
+++ b/test/helpers/setup-migration.js
@@ -37,7 +37,9 @@ export default function setupMigrationTest(filename, mocks) {
   });
 
   mockRequire('fs', {
-    existsSync: path => path.endsWith('package-lock.json') || path.includes('/.codeshift/')
+    existsSync: path => path.includes('/.codeshift/') ||
+      (language === 'js' && path.endsWith('package-lock.json')) ||
+      (language === 'ruby' && path.endsWith('Gemfile'))
   });
 
   mockRequire.reRequire('../../src/utils');

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -229,10 +229,9 @@ describe('SDK inspection', () => {
         version: '^2.0.0'
       }]);
 
-      inspectGemfile = mockInspectGemfile({
-        name: 'percy-ruby-sdk',
-        version: '1.0.0'
-      });
+      inspectGemfile = mockInspectGemfile([
+        { name: 'percy-ruby-sdk', version: '= 1.0' }
+      ]);
     });
 
     it('inspects the gemfile to guess the installed SDK', async () => {

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -144,7 +144,8 @@ describe('CLI installation', () => {
   });
 
   it('warns and uses npm when both a yarn.lock and package-lock.json exists', async () => {
-    mockRequire('fs', { existsSync: () => true });
+    let existsSync = path => path.endsWith('.lock') || path.endsWith('-lock.json');
+    mockRequire('fs', { existsSync });
     await Migrate('--only-cli');
 
     expect(run.npm.calls[0].args)

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -192,7 +192,7 @@ describe('CLI installation', () => {
 
     expect(logger.stdout).toEqual([]);
     expect(logger.stderr).toEqual([
-      '[percy] Error: npm failed with exit code 3\n'
+      '[percy] Error: npm failed with exit code 3.\n'
     ]);
   });
 });

--- a/test/migrations/capybara.test.js
+++ b/test/migrations/capybara.test.js
@@ -59,7 +59,7 @@ describe('Migrations - percy-capybara', () => {
   });
 
   it('asks to remove tasks even when not installed', async () => {
-    inspectGemfile.output = {};
+    inspectGemfile.output = [];
 
     await Migrate('percy-capybara', '--skip-cli');
 

--- a/test/migrations/capybara.test.js
+++ b/test/migrations/capybara.test.js
@@ -1,0 +1,124 @@
+import expect from 'expect';
+import { codeshift } from '../../src/utils';
+import {
+  Migrate,
+  logger,
+  setupMigrationTest,
+  mockRequire
+} from '../helpers';
+
+describe('Migrations - percy-capybara', () => {
+  let rubycodeshiftbin = codeshift.ruby.bin;
+  let prompts, run;
+
+  describe('with an old sdk installed', () => {
+    beforeEach(() => {
+      ({ prompts, run } = setupMigrationTest('capybara', {
+        installed: { version: '4.3.3' },
+        mockCommands: {
+          [rubycodeshiftbin]: () => ({ status: 0 }),
+          bundle: () => ({ status: 0 })
+        },
+        mockPrompts: { filePaths: ['specs/my_test.rb'] }
+      }));
+    });
+
+    it('upgrades the sdk', async () => {
+      await Migrate('percy-capybara', '--skip-cli');
+
+      expect(prompts[1]).toEqual({
+        type: 'confirm',
+        name: 'upgradeSDK',
+        message: 'Upgrade SDK to percy-capybara@^5.0.0?',
+        default: true
+      });
+
+      expect(run.bundle.calls[0].args).toEqual(['remove', 'percy-capybara']);
+
+      expect(logger.stderr).toEqual([]);
+      expect(logger.stdout).toEqual([
+        '[percy] Migration complete!\n'
+      ]);
+    });
+
+    it('runs the codemod to convert to the new API', async () => {
+      await Migrate('percy-capybara', '--skip-cli');
+
+      expect(prompts[2]).toEqual({
+        type: 'confirm',
+        name: 'doTransform',
+        message: 'The Capybara API has breaking changes, automatically convert to the new API?',
+        default: true
+      });
+
+      expect(run[rubycodeshiftbin].calls[0].args).toEqual([
+        `--transform=${require.resolve('../../transforms/capybara.rb')}`,
+        'specs/my_test.rb'
+      ]);
+
+      expect(logger.stderr).toEqual([]);
+      expect(logger.stdout).toEqual([
+        '[percy] Migration complete!\n'
+      ]);
+    });
+  });
+
+  it('asks to remove tasks even when not installed', async () => {
+    ({ prompts, run } = setupMigrationTest('capybara', {
+      installed: { version: '' },
+      mockCommands: {
+        [rubycodeshiftbin]: () => ({ status: 0 }),
+        bundle: () => ({ status: 0 })
+      },
+      mockPrompts: { filePaths: ['specs/my_test.rb'] }
+    }));
+
+    await Migrate('percy-capybara', '--skip-cli');
+
+    expect(prompts[2]).toEqual({
+      type: 'confirm',
+      name: 'doTransform',
+      message: 'The Capybara API has breaking changes, automatically convert to the new API?',
+      default: true
+    });
+
+    expect(run[rubycodeshiftbin].calls[0].args).toEqual([
+      `--transform=${require.resolve('../../transforms/capybara.rb')}`,
+      'specs/my_test.rb'
+    ]);
+
+    expect(logger.stderr).toEqual([
+      '[percy] The specified SDK was not found in your dependencies\n'
+    ]);
+    expect(logger.stdout).toEqual([
+      '[percy] Migration complete!\n'
+    ]);
+  });
+
+  it('catches errors', async () => {
+    ({ prompts, run } = setupMigrationTest('capybara', {
+      installed: { version: '4.3.3' },
+      mockCommands: {
+        [rubycodeshiftbin]: () => ({ status: 0 }),
+        bundle: () => ({ status: 0 })
+      },
+      mockPrompts: { filePaths: ['specs/my_test.rb'] }
+    }));
+
+    mockRequire('child_process', {
+      execSync: (cmd, args, options) => {
+        throw new Error('The error that happens here');
+      }
+    });
+
+    await Migrate('percy-capybara', '--skip-cli');
+
+    expect(logger.stderr).toEqual([
+      '[percy] Encountered an error inspecting Gemfile\n',
+      '[percy] The error that happens here\n'
+    ]);
+    expect(logger.stdout).toEqual([
+      '[percy] Migration complete!\n'
+    ]);
+  });
+});

--- a/test/migrations/capybara.test.js
+++ b/test/migrations/capybara.test.js
@@ -4,15 +4,15 @@ import {
   Migrate,
   logger,
   setupMigrationTest,
-  mockRequire
+  mockGemfile
 } from '../helpers';
 
 describe('Migrations - percy-capybara', () => {
   let rubycodeshiftbin = codeshift.ruby.bin;
-  let inspectGemfile, prompts, run;
+  let prompts, run;
 
   beforeEach(() => {
-    ({ inspectGemfile, prompts, run } = setupMigrationTest('capybara', {
+    ({ prompts, run } = setupMigrationTest('capybara', {
       installed: { version: '4.3.3' },
       mockCommands: { [rubycodeshiftbin]: () => ({ status: 0 }) },
       mockPrompts: { filePaths: ['specs/my_test.rb'] }
@@ -59,7 +59,7 @@ describe('Migrations - percy-capybara', () => {
   });
 
   it('asks to remove tasks even when not installed', async () => {
-    inspectGemfile.output = [];
+    mockGemfile('');
 
     await Migrate('percy-capybara', '--skip-cli');
 

--- a/test/migrations/capybara.test.js
+++ b/test/migrations/capybara.test.js
@@ -9,69 +9,57 @@ import {
 
 describe('Migrations - percy-capybara', () => {
   let rubycodeshiftbin = codeshift.ruby.bin;
-  let prompts, run;
+  let inspectGemfile, prompts, run;
 
-  describe('with an old sdk installed', () => {
-    beforeEach(() => {
-      ({ prompts, run } = setupMigrationTest('capybara', {
-        installed: { version: '4.3.3' },
-        mockCommands: {
-          [rubycodeshiftbin]: () => ({ status: 0 }),
-          bundle: () => ({ status: 0 })
-        },
-        mockPrompts: { filePaths: ['specs/my_test.rb'] }
-      }));
+  beforeEach(() => {
+    ({ inspectGemfile, prompts, run } = setupMigrationTest('capybara', {
+      installed: { version: '4.3.3' },
+      mockCommands: { [rubycodeshiftbin]: () => ({ status: 0 }) },
+      mockPrompts: { filePaths: ['specs/my_test.rb'] }
+    }));
+  });
+
+  it('upgrades the sdk', async () => {
+    await Migrate('percy-capybara', '--skip-cli');
+
+    expect(prompts[1]).toEqual({
+      type: 'confirm',
+      name: 'upgradeSDK',
+      message: 'Upgrade SDK to percy-capybara@^5.0.0?',
+      default: true
     });
 
-    it('upgrades the sdk', async () => {
-      await Migrate('percy-capybara', '--skip-cli');
+    expect(run.bundle.calls[0].args).toEqual(['remove', 'percy-capybara']);
 
-      expect(prompts[1]).toEqual({
-        type: 'confirm',
-        name: 'upgradeSDK',
-        message: 'Upgrade SDK to percy-capybara@^5.0.0?',
-        default: true
-      });
+    expect(logger.stderr).toEqual([]);
+    expect(logger.stdout).toEqual([
+      '[percy] Migration complete!\n'
+    ]);
+  });
 
-      expect(run.bundle.calls[0].args).toEqual(['remove', 'percy-capybara']);
+  it('runs the codemod to convert to the new API', async () => {
+    await Migrate('percy-capybara', '--skip-cli');
 
-      expect(logger.stderr).toEqual([]);
-      expect(logger.stdout).toEqual([
-        '[percy] Migration complete!\n'
-      ]);
+    expect(prompts[2]).toEqual({
+      type: 'confirm',
+      name: 'doTransform',
+      message: 'The Capybara API has breaking changes, automatically convert to the new API?',
+      default: true
     });
 
-    it('runs the codemod to convert to the new API', async () => {
-      await Migrate('percy-capybara', '--skip-cli');
+    expect(run[rubycodeshiftbin].calls[0].args).toEqual([
+      `--transform=${require.resolve('../../transforms/capybara.rb')}`,
+      'specs/my_test.rb'
+    ]);
 
-      expect(prompts[2]).toEqual({
-        type: 'confirm',
-        name: 'doTransform',
-        message: 'The Capybara API has breaking changes, automatically convert to the new API?',
-        default: true
-      });
-
-      expect(run[rubycodeshiftbin].calls[0].args).toEqual([
-        `--transform=${require.resolve('../../transforms/capybara.rb')}`,
-        'specs/my_test.rb'
-      ]);
-
-      expect(logger.stderr).toEqual([]);
-      expect(logger.stdout).toEqual([
-        '[percy] Migration complete!\n'
-      ]);
-    });
+    expect(logger.stderr).toEqual([]);
+    expect(logger.stdout).toEqual([
+      '[percy] Migration complete!\n'
+    ]);
   });
 
   it('asks to remove tasks even when not installed', async () => {
-    ({ prompts, run } = setupMigrationTest('capybara', {
-      installed: { version: '' },
-      mockCommands: {
-        [rubycodeshiftbin]: () => ({ status: 0 }),
-        bundle: () => ({ status: 0 })
-      },
-      mockPrompts: { filePaths: ['specs/my_test.rb'] }
-    }));
+    inspectGemfile.output = {};
 
     await Migrate('percy-capybara', '--skip-cli');
 

--- a/test/migrations/capybara.test.js
+++ b/test/migrations/capybara.test.js
@@ -82,31 +82,4 @@ describe('Migrations - percy-capybara', () => {
       '[percy] Migration complete!\n'
     ]);
   });
-
-  it('catches errors', async () => {
-    ({ prompts, run } = setupMigrationTest('capybara', {
-      installed: { version: '4.3.3' },
-      mockCommands: {
-        [rubycodeshiftbin]: () => ({ status: 0 }),
-        bundle: () => ({ status: 0 })
-      },
-      mockPrompts: { filePaths: ['specs/my_test.rb'] }
-    }));
-
-    mockRequire('child_process', {
-      execSync: (cmd, args, options) => {
-        throw new Error('The error that happens here');
-      }
-    });
-
-    await Migrate('percy-capybara', '--skip-cli');
-
-    expect(logger.stderr).toEqual([
-      '[percy] Encountered an error inspecting Gemfile\n',
-      '[percy] Error: The error that happens here\n'
-    ]);
-    expect(logger.stdout).toEqual([
-      '[percy] Migration complete!\n'
-    ]);
-  });
 });

--- a/test/migrations/capybara.test.js
+++ b/test/migrations/capybara.test.js
@@ -115,7 +115,7 @@ describe('Migrations - percy-capybara', () => {
 
     expect(logger.stderr).toEqual([
       '[percy] Encountered an error inspecting Gemfile\n',
-      '[percy] The error that happens here\n'
+      '[percy] Error: The error that happens here\n'
     ]);
     expect(logger.stdout).toEqual([
       '[percy] Migration complete!\n'

--- a/test/migrations/capybara.test.js
+++ b/test/migrations/capybara.test.js
@@ -58,8 +58,8 @@ describe('Migrations - percy-capybara', () => {
     ]);
   });
 
-  it('asks to remove tasks even when not installed', async () => {
-    mockGemfile('');
+  it('asks to transform files even when not installed', async () => {
+    mockGemfile('gem "foobar", "1.0"');
 
     await Migrate('percy-capybara', '--skip-cli');
 

--- a/test/unit/codeshift.test.js
+++ b/test/unit/codeshift.test.js
@@ -5,10 +5,16 @@ let { codeshift } = require('../../src/utils.js');
 describe('Installing codeshift libraries', () => {
   let run;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    // set the `bin` path in the `codeshift` util
+    await codeshift.js?.install();
+    await codeshift.ruby?.install();
+
     run = mockCommands({
       npm: () => ({ status: 0 }),
-      [codeshift.js.bin]: () => ({ status: 0 })
+      gem: () => ({ status: 0 }),
+      [codeshift.js.bin]: () => ({ status: 0 }),
+      [codeshift.ruby.bin]: () => ({ status: 0 })
     });
 
     mockRequire('fs', {
@@ -26,6 +32,15 @@ describe('Installing codeshift libraries', () => {
     expect(run.npm.calls[0].args[2]).toEqual('jscodeshift');
   });
 
+  it('installs codeshift for Ruby SDKs', async () => {
+    await codeshift.run('ruby', ['foo/bar']);
+
+    expect(run.gem.calls[0].args[0]).toEqual('install');
+    expect(run.gem.calls[0].args[1]).toEqual('codeshift');
+    expect(run.gem.calls[0].args[2].endsWith('.codeshift/ruby')).toBe(true);
+    expect(run.gem.calls[0].args[3]).toEqual('--no-document');
+  });
+
   describe('with .codeshift present', () => {
     beforeEach(() => {
       mockRequire('fs', {
@@ -38,7 +53,13 @@ describe('Installing codeshift libraries', () => {
     it('does not install jscodeshift for JS SDKs', async () => {
       await codeshift.run('js', ['foo/bar']);
 
-      expect(run.npm.calls).toEqual(undefined);
+      expect(run.gem.calls).toEqual(undefined);
+    });
+
+    it('does not install codeshift for Ruby SDKs', async () => {
+      await codeshift.run('ruby', ['foo/bar']);
+
+      expect(run.gem.calls).toEqual(undefined);
     });
   });
 });

--- a/transforms/capybara.rb
+++ b/transforms/capybara.rb
@@ -1,0 +1,42 @@
+class Transform < Parser::TreeRewriter
+  def on_send(node)
+    # match 'Percy.snapshot'
+    if (node.children[0]&.type == :const and
+        node.children[0].loc.name.source == 'Percy' and
+        node.children[1] == :snapshot)
+      obj_ast, _, page_ast, hash_ast = node.children
+
+      # get the page argument position and name
+      page_range = page_ast.loc.expression
+      page_var = page_range.source
+
+      # find the `name` snapshot option index
+      name_idx = hash_ast.children.index do |item|
+        item.children.first.loc.expression.source == 'name'
+      end
+
+      # get the actual name, and the range of the ast
+      name_ast = hash_ast.children[name_idx]
+      name_str = name_ast.children.last.loc.expression.source
+      name_range = name_ast.loc.expression
+
+      # if there is a following option, adjust the ast position to include spaces
+      if next_ast = hash_ast.children&.[](name_idx + 1)
+        name_range = name_range.with(end_pos: next_ast.loc.expression.begin_pos)
+
+      # if there is only a single name option, adjust the ast position to encompass the hash
+      elsif hash_ast.children.length === 1
+        name_range = hash_ast.loc.expression.with(begin_pos: page_range.end_pos)
+      end
+
+      # replace 'Percy' with the page variable
+      replace(obj_ast.loc.expression, page_var)
+      # replace '.snapshot' with `.percy_snapshot`
+      replace(node.loc.selector, 'percy_snapshot')
+      # replace the page argument with the snapshot name
+      replace(page_range, name_str)
+      # remove the name argument from snapshot options
+      remove(name_range)
+    end
+  end
+end


### PR DESCRIPTION
## Purpose

v5 of the `percy-capybara` SDK has significant API changes (`Percy.snapshot(driver, { name: '' })` to `page.percy_snapshot('name')`). With those significant changes, we would like to provide a codemod to automatically change the API for our users. The easier it is to upgrade to the CLI based SDK, the better. The first step to making this possible was taken care of in #94 -- where we install the codeshift library into language specific folders. 

## Approach

With #94 taking care of installing the codeshift library for each language, we can implement installing the Ruby codeshift library.  There's also a Ruby AST to transform to the SDK's new API. From there, similar to our JS SDKs, we parse the dependency file (`Gemfile`) to auto-discover the installed SDK version. 

Shout out @wwilsman for crushing the AST. 💪🏼 

Once this merges, we can also merge #19 
